### PR TITLE
order of ops error

### DIFF
--- a/trlx/model/accelerate_ppo_model.py
+++ b/trlx/model/accelerate_ppo_model.py
@@ -40,7 +40,7 @@ class AcceleratePPOModel(AccelerateRLModel):
         gen_len = response_tensors.shape[1]
         for t in reversed(range(gen_len)):
             nextvalues = all_values[:, t + 1] if t < gen_len - 1 else 0.0
-            delta = all_rewards[:, t] + self.config.method.gamma * nextvalues - all_values[:, t]
+            delta = all_rewards[:, t] + self.config.method.gamma * (nextvalues - all_values[:, t])
             lastgaelam = delta + self.config.method.gamma * self.config.method.lam * lastgaelam
             advantages_reversed.append(lastgaelam)
         advantages = torch.stack(advantages_reversed[::-1]).transpose(0, 1)


### PR DESCRIPTION
I have been looking at the trl repo for a few weeks and think there is a order of ops mistake in the ppo loss code. I noticed the same code is used in trlx.

The existing code is
delta = all_rewards[:, t] + self.config.method.gamma * nextvalues - all_values[:, t]

I think it should be 
delta = all_rewards[:, t] + self.config.method.gamma * (nextvalues - all_values[:, t])

this would make the case where gamma=0 be delta = reward instead of delta = reward - value, and the case of 0 reward and constant value delta would be 0 instead of -value. The default value of gamma is 1 in the trl repo which would cause both of these lines of code to have identical behavior.