### PR TITLE
QOL fixes

### DIFF
--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -70,7 +70,7 @@ class AccelerateRLModel(BaseRLModel):
             #TODO(dahoas): swap this out for custom generate to if this fixes issue
             _ = self.model(self.dummy_input.to(self.accelerator.device))  # Dummy pass to make things play nice with accelerate
             # Removed synced gpus
-            response = self.model.generate(query_tensors, **self.config.method.gen_kwargs)
+            response = self.model.generate(query_tensors, pad_token_id=self.tokenizer.eos_token_id, **self.config.method.gen_kwargs)
             response_tensors = response[:, query_tensors.size()[1] : query_tensors.size()[1] + self.config.train.gen_size]
         response_text = self.tokenizer.batch_decode(response_tensors)
         return query_tensors, response_tensors, response_text

--- a/trlx/model/accelerate_ppo_model.py
+++ b/trlx/model/accelerate_ppo_model.py
@@ -93,7 +93,7 @@ class AcceleratePPOModel(AccelerateRLModel):
         self.iter_count = 0
         self.epoch = 0
         while self.iter_count < self.config.train.total_steps or self.epoch <= self.config.train.epochs:
-            for batch in tqdm(rollout_loader, disable=not self.accelerator.is_local_main_process):
+            for batch in rollout_loader:
 
                 query_tensors = batch.query_tensors.to(self.accelerator.device)
                 response_tensors = batch.response_tensors.to(self.accelerator.device)

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -43,7 +43,7 @@ class PPOOrchestrator(Orchestrator):
 		ppo_rl_elements = []
 		stats = {}
 		clock = Clock()
-		for i in tqdm(range(num_rollouts // self.chunk_size)):
+		for i in range(num_rollouts // self.chunk_size):
 			# Get next batch in prompt dataset and refresh if exhausted
 			try :
 				batch : PromptBatch = next(self.pipeline_iterator)


### PR DESCRIPTION
Removes the pad_token_id warning.

Removes tqdm. Everything is logged to wandb anyway, tqdm seemed irrelevant. 