### PR TITLE
Support for Soft Prompts in PPO Model

### DIFF
--- a/configs/ppo_softprompt_config.yml
+++ b/configs/ppo_softprompt_config.yml
@@ -1,0 +1,54 @@
+model:
+  model_path : "lvwerra/gpt2-imdb"  # Name of hf model to load
+  tokenizer_path : "gpt2"  # Name of hf tokenizer to load
+  model_type : "AcceleratePPOSoftpromptModel"  # Name of accelerate model type to load
+  device : "cuda"  # Train device
+  num_layers_unfrozen : -1  # Number of bottom layers to freeze during training
+  n_soft_tokens : 1  # Number of (prefix) soft prompt tokens
+  initialize_from_vocab : True  # Initialize learned soft prompt embeddings from vocab
+
+train:
+  n_ctx : 512  # Size of LM context
+  epochs : 10  # Train for max(epochs, total_steps)
+  total_steps : 80000  # Train for max(epochs, total_steps)
+  batch_size : 128  # batch size
+  grad_clip : 1.0  # gradient clipping threshold
+
+  lr_ramp_steps : 100  # learning rate warm up
+  lr_decay_steps : 79000  # learning rate decay
+  weight_decay : 1.0e-6  # weight decay param
+  learning_rate_init : 1.412e-4  # init learning rate
+  learning_rate_target : 1.412e-4  # target final learning rate
+
+  log_interval : 25  # log interval
+  checkpoint_interval : 1000000  # checkpoint interval
+  eval_interval : 16  # eval interval
+
+  pipeline : "PPOPipeline"  # prompt pipeline to load
+  orchestrator : "PPOOrchestrator"  # orchestrator to load
+
+  input_size : 4  # max input size
+  gen_size : 48  # max gen size, n_soft_tokens will be added
+
+  accelerate : True  # Use accelerate
+  accelerate_config_path : ""  # Path to accelerate config(for logging purposes)
+
+method:
+  name : 'ppoconfig'  # Name of RL method config
+  num_rollouts : 128  # Number of rollouts to collect per epoch
+  chunk_size : 128  # Number of rollouts to collect in one loop of orchestrator
+  ppo_epochs : 4  # Number of ppo epochs
+  init_kl_coef : 0.2  # init kl coefficient
+  target : 6  # target kl coefficient
+  horizon : 10000  # PPO horizon
+  gamma : 1  # PPO discount
+  lam : 0.95  # PPO lambda
+  cliprange : 0.2  # clip range
+  cliprange_value : 0.2  # clip range
+  vf_coef : 0.2  # value term weight
+  gen_kwargs :
+    max_length : 48  # LM max sample gen length, n_soft_tokens will be added
+    min_length : 48  # LM min sample gen length, n_soft_tokens will be added
+    top_k : 0.0  # top k
+    top_p : 1.0  # top p
+    do_sample : True  # sample

--- a/examples/ppo_softprompt_sentiments.py
+++ b/examples/ppo_softprompt_sentiments.py
@@ -1,0 +1,45 @@
+from typing import List
+
+import torch
+from torch import nn
+from transformers import pipeline
+
+import wandb
+from trlx.data.configs import TRLConfig
+from trlx.model.accelerate_ppo_model import AcceleratePPOModel
+from trlx.model.accelerate_ppo_softprompt_model import AcceleratePPOSoftpromptModel
+from trlx.orchestrator.ppo_orchestrator import PPOOrchestrator
+from trlx.pipeline.ppo_pipeline import PPOPipeline
+from trlx.utils.loading import get_model, get_orchestrator, get_pipeline
+
+
+if __name__ == "__main__":
+    cfg = TRLConfig.load_yaml("configs/ppo_softprompt_config.yml")
+
+    sentiment_pipe = pipeline(
+        "sentiment-analysis", "lvwerra/distilbert-imdb", device=-1
+    )
+
+    def reward_fn(samples: List[str]):
+        sent_kwargs = {
+            "return_all_scores": True,
+            "function_to_apply": None,
+            "batch_size": cfg.method.chunk_size,
+        }
+        pipe_outputs = sentiment_pipe(samples, **sent_kwargs)
+        scores = torch.tensor([output[1]["score"] for output in pipe_outputs])
+        return scores
+
+    model: AcceleratePPOSoftpromptModel = get_model(cfg.model.model_type)(cfg)
+    
+    if model.accelerator.is_main_process:
+        wandb.watch(model.model)
+    
+    pipeline: PPOPipeline = get_pipeline(cfg.train.pipeline)(model.tokenizer, cfg)
+    orch: PPOOrchestrator = get_orchestrator(cfg.train.orchestrator)(
+        model, pipeline, reward_fn=reward_fn, chunk_size=cfg.method.chunk_size
+    )
+    orch.make_experience(cfg.method.num_rollouts)
+    model.learn()
+
+    print("DONE!")

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -29,6 +29,8 @@ class ModelConfig:
     model_type : str # One of the architectures present in framework.model
     device : str = ''
     num_layers_unfrozen : int = -1
+    n_soft_tokens: int = None # soft prompt support
+    initialize_from_vocab: bool = True # soft prompt support
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):

--- a/trlx/model/accelerate_ppo_softprompt_model.py
+++ b/trlx/model/accelerate_ppo_softprompt_model.py
@@ -1,0 +1,138 @@
+import os
+from abc import abstractmethod
+from typing import Dict, Iterable, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from accelerate import Accelerator
+from torch.utils.data import DataLoader
+from torchtyping import TensorType
+from tqdm import tqdm
+from transformers import AutoConfig, AutoTokenizer
+
+import wandb
+from trlx.data.accelerate_base_datatypes import PromptBatch
+from trlx.data.configs import TRLConfig
+from trlx.model import BaseRLModel, register_model
+from trlx.model.accelerate_base_model import AccelerateRLModel
+from trlx.model.accelerate_ppo_model import AcceleratePPOModel
+from trlx.model.nn.ppo_models import GPTHeadWithValueModel
+from trlx.pipeline.ppo_pipeline import PPORolloutStorage
+from trlx.utils import Clock, rampup_decay, safe_mkdir, topk_mask
+from trlx.utils.modeling import clip_by_value, logprobs_from_logits, whiten
+
+
+class SoftEmbedding(nn.Module):
+    def __init__(self, 
+                wte: nn.Embedding,
+                n_tokens: int = 10, 
+                random_range: float = 0.5,
+                initialize_from_vocab: bool = True):
+        """appends learned embedding as prefix
+
+        From: https://github.com/kipgparker/soft-prompt-tuning
+
+        Args:
+            wte (nn.Embedding): original transformer word embedding
+            n_tokens (int, optional): number of tokens for task. Defaults to 10.
+            random_range (float, optional): range to init embedding (if not initialize from vocab). Defaults to 0.5.
+            initialize_from_vocab (bool, optional): initalizes from default vocab. Defaults to True.
+        """
+        super(SoftEmbedding, self).__init__()
+        self.wte = wte
+        self.n_tokens = n_tokens
+        self.learned_embedding = nn.parameter.Parameter(self.initialize_embedding(wte,
+                                                                               n_tokens, 
+                                                                               random_range, 
+                                                                               initialize_from_vocab))
+            
+    def initialize_embedding(self, 
+                             wte: nn.Embedding,
+                             n_tokens: int = 10, 
+                             random_range: float = 0.5, 
+                             initialize_from_vocab: bool = True):
+        """initializes learned embedding
+        Args:
+            same as __init__
+        Returns:
+            torch.float: initialized using original schemes
+        """
+        if initialize_from_vocab:
+            return self.wte.weight[:n_tokens].clone().detach()
+        return torch.FloatTensor(n_tokens, wte.weight.size(1)).uniform_(-random_range, random_range)
+            
+    def forward(self, tokens):
+        """run forward pass
+        Args:
+            tokens (torch.long): input tokens before encoding
+        Returns:
+            torch.float: encoding of text concatenated with learned task specifc embedding
+        """
+        input_embedding = self.wte(tokens[:, self.n_tokens:])
+        learned_embedding = self.learned_embedding.repeat(input_embedding.size(0), 1, 1)
+        return torch.cat([learned_embedding, input_embedding], 1)
+
+
+@register_model
+class AcceleratePPOSoftpromptModel(AcceleratePPOModel):
+    def __init__(self, config, train_mode=True):
+        self.store = PPORolloutStorage()
+        super().__init__(config, self.store)
+
+        assert config.model.n_soft_tokens > 0, "Number of soft prompt tokens should be >=1"
+        
+        self.soft_dummy_token_id = 50256 # dummy token for padding soft prompts
+        self.n_soft_tokens = config.model.n_soft_tokens
+
+        s_wte = SoftEmbedding(self.model.gpt.get_input_embeddings(), 
+                      n_tokens=config.model.n_soft_tokens, 
+                      initialize_from_vocab=config.model.initialize_from_vocab)
+
+        self.model.gpt.set_input_embeddings(s_wte)
+
+        # account for extra prefix tokens
+        self.config.train.gen_size += self.n_soft_tokens
+        self.config.method.gen_kwargs["max_length"] += self.n_soft_tokens
+        self.config.method.gen_kwargs["min_length"] += self.n_soft_tokens
+
+    def act(
+        self, data: PromptBatch
+    ) -> Tuple[
+        TensorType["chunk_size", "input_length"],
+        TensorType["chunk_size", "gen_size"],
+        Iterable[str],
+    ]:
+        data.tokens = torch.cat([torch.full((data.tokens.shape[0],self.n_soft_tokens), self.soft_dummy_token_id), data.tokens], 1)
+        query_tensors = data.tokens.to(
+            self.accelerator.device
+        )  # [B, N] #TODO(dahoas): This may need to be changed
+        with torch.no_grad():
+            # TODO(dahoas): swap this out for custom generate to if this fixes issue
+            
+            # need to pad attention_mask and input_ids to be full seq_len + n_learned_tokens
+            # even though it does not matter what you pad input_ids with, it's just to make HF happy
+            batch_dim = self.dummy_input.shape[0]
+            self.dummy_input = torch.cat([torch.full((batch_dim,self.n_soft_tokens), self.soft_dummy_token_id), self.dummy_input], 1)
+            _ = self.model(
+                self.dummy_input.to(self.accelerator.device)
+            )  # Dummy pass to make things play nice with accelerate
+            # Removed synced gpus
+            attn_mask = torch.full((query_tensors.shape[0],query_tensors.shape[1]), 1).to(
+                self.accelerator.device
+            )
+            response = self.model.generate(
+                query_tensors,
+                pad_token_id=self.tokenizer.eos_token_id,
+                attention_mask=attn_mask,
+                use_cache=False, # needed for softprompt compatibility
+                **self.config.method.gen_kwargs
+            )
+            response_tensors = response[
+                :,
+                query_tensors.size()[1] : query_tensors.size()[1]
+                + self.config.train.gen_size,
+            ]
+            query_tensors = query_tensors[:, self.n_soft_tokens:] # remove softprompt padding tokens
+        response_text = self.tokenizer.batch_decode(response_tensors)
+        return query_tensors, response_tensors, response_text


### PR DESCRIPTION
For adding support to soft prompts in models, fixes https://github.com/CarperAI/trlx/issues/29.

Changes:
- Sample config and example added with minor changes from original ppo versions.
- ModelConfig has two new params to support soft prompt settings.
- New accelerate model added with soft prompt implementation.

Not tested with full training run, but runs training steps in added example script.