### PR TITLE
[update] Improve package setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,19 @@ The training pipeline is broken into four pieces:
 
 Adding a task for RLHF training depends on the desired training method and pre-existing data. If we are online and have no reward labeled data this is as simple as writing a new prompt pipeline, which supplies prompts for exploration, and a new reward function to be passed into the `PPOOrchestrator` class.
 
+## Installation
+```bash
+git clone https://github.com/CarperAI/trlx.git
+cd trlx
+pip install -e ".[dev]"
+```
+
 ## Example: How to add a task
 
 In the below we implement a sentiment learning task.
 
-### Installation
+### Configure `accelerate`
 
-Install the repo:
-```bash
-python setup.py develop
-```
-
-Configure accelerate:
 ```bash
 accelerate config
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-accelerate==0.12.0
-datasets==2.4.0
-deepspeed==0.7.3
-einops==0.4.1
-numpy==1.23.2
-pre-commit==2.20.0
-tqdm==4.64.0
-transformers==4.21.2
-wandb==0.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,14 @@
 name = trlx
 author = Alex Havrilla
 version = 1.0.0
+url = https://github.com/CarperAI/trlx
+description = A repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF)
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
 
 [options]
+packages = find:
 install_requires =
     accelerate
     datasets
@@ -14,3 +20,14 @@ install_requires =
     transformers
     wandb
     torchtyping
+
+[options.extras_require]
+dev =
+    pytest
+    pytest-cov
+
+[options.packages.find]
+exclude =
+    examples*
+    docs*
+    tests*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ install_requires =
 
 [options.extras_require]
 dev =
+    black
+    flake8
     pytest
     pytest-cov
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,20 +11,21 @@ license = MIT
 [options]
 packages = find:
 install_requires =
-    accelerate
+    accelerate>=0.12.0
     datasets
-    deepspeed
-    einops
-    numpy
-    tqdm
-    transformers
-    wandb
+    deepspeed>=0.7.3
+    einops>=0.4.1
+    numpy>=1.23.2
     torchtyping
+    transformers>=4.21.2
+    tqdm
+    wandb
 
 [options.extras_require]
 dev =
     black
     flake8
+    pre-commit
     pytest
     pytest-cov
 

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -14,7 +14,7 @@ class TestHydraHead(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         print("Testing Hydra model...")
-        config = TRLConfig.load_yaml("../configs/test_config.yml")
+        config = TRLConfig.load_yaml("configs/test_config.yml")
         cls.hydra_model = GPTHydraHeadWithValueModel(
             config.model.model_path, config.model.num_layers_unfrozen
         )
@@ -70,7 +70,3 @@ class TestHydraHead(unittest.TestCase):
             logits_diff = torch.sum(unfrozen_logits - frozen_logits).item()
             self.assertEqual(hs_diff, 0)
             self.assertEqual(logits_diff, 0)
-
-
-# Run unittests: python -m unittest discover -s . -p "test_*"
-# Or python -m unittest test_ppo.py


### PR DESCRIPTION
This PR addresses package setup issues with the following updates:

- Adds package finding to `setup.cfg` to avoid "multiple top-level packages" errors during new environment installs. 
  - __Related issue__: #41
- Updates `README.md` installation instructions to use `pip install -e ...`, as  `python setup.py ...` is deprecated and should be replaced with pip tools ([reference guide](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)).
- Adds separate `dev` dependencies to `setup.cfg` to avoid forcing `dev` dependencies on package install.
    - Adopts `pytest` as the test runner.
- Renames `unittests` to `tests` to avoid confusion with `unittest` module and adhere to common Python unit-test directory naming.