### PR TITLE
Add initial issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+---
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior to help us improve trlX 
+labels:
+- bug
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      #### Before submitting your bug report, please check to see that the 
+      issue hasn't already been reported and/or fixed in a latest version.
+      [Search Issues][Issue Search].
+    
+      If you're asking a question or seeking support, please consider creating a
+      new [GitHub discussion][Discussions] or heading over to CarperAI's
+      [Discord server][CarperAI Discord].
+
+
+      [Issue Search]: https://github.com/CarperAI/trlx/search?q=is%3Aissue&type=issues
+
+      [Discussions]: https://github.com/CarperAI/trlx/discussions
+
+      [CarperAI Discord]: https://discord.gg/X2gHZMRP6m
+
+- type: textarea
+  attributes:
+    label: 🐛 Describe the bug
+    description: >-
+      Please provide a clear and concise description of what the problem is,
+      preferably with self-contained code to reproduce the issue. You may want
+      to follow the suggestions outlined in [this guide][Guide]. If you observe
+      an error, please paste the error message including the full traceback.
+
+
+      [Guide]: https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports
+
+    placeholder: |
+      A description of what the bug is.
+
+      ```python
+      # Sample code to reproduce the bug, if applicable.
+      ```
+
+      ```
+      The error message, with the full traceback.
+      ```
+
+  validations:
+    required: true
+
+- type: input
+  attributes:
+    label: Which trlX version are you using?
+    placeholder: For example, `trlx==1.0.0`
+
+- type: input
+  attributes:
+    label: Additional system and package information
+    placeholder: Python version, `transformers` version, OS (Linux/Mac/Windows/WSL), etc.
+
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🐠! 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,25 @@
+---
+name: 📚 Documentation
+description: Report an issue related to https://trlx.readthedocs.io/en/latest/index.html
+labels:
+- documentation
+
+body:
+- type: textarea
+  attributes:
+    label: 📚 The doc issue
+    description: >
+      Please provide a clear and concise description of what content in https://trlx.readthedocs.io/en/latest/index.html is an issue. 
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Suggest a potential alternative/fix
+    description: >
+      Tell us how we could improve the documentation in this regard.
+
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🐠!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+---
+name: 🚀 Feature Request
+description: Submit a proposal/request for a new trlX feature
+labels:
+- feature request
+
+body:
+- type: textarea
+  attributes:
+    label: 🚀 The feature, motivation, and pitch
+    description: >
+      Please provide a clear and concise description of the feature proposal.
+      Outline the motivation for the proposal; is your feature request related to a
+      specific problem? E.g., *"I'm working on X and would like Y to be
+      possible"*. If this is related to another GitHub issue, please link here
+      too.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Alternatives
+    description: >
+      A description of any alternative solutions or features you've considered,
+      if any.
+
+- type: textarea
+  attributes:
+    label: Additional context
+    description: >
+      Add any other context or screenshots about the feature request.
+
+- type: markdown
+  attributes:
+    value: >
+      Thanks for contributing 🐠!


### PR DESCRIPTION
This PR adds initial issue templates to help organize/track issues in a consistent manner.