### PR TITLE
Add ckpt/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ nbs/wandb/
 wandb/
 
 OUT/
+
+ckpts/


### PR DESCRIPTION
This is a minor PR to add `ckpts/` dir name to the `.gitignore` file. I think while saving model the default dir name is `ckpts/`. I think this will keep the git status clean.