### PR TITLE
Fix pipeline's context overflow

### DIFF
--- a/examples/ilql_sentiments.py
+++ b/examples/ilql_sentiments.py
@@ -18,6 +18,7 @@ def main():
         "lvwerra/distilbert-imdb",
         top_k=2,
         truncation=True,
+        batch_size=256,
         device=-1,
     )
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -26,6 +26,7 @@ def main():
         "lvwerra/distilbert-imdb",
         top_k=2,
         truncation=True,
+        batch_size=256,
         device=device,
     )
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -1,17 +1,36 @@
-# Generates positive movie reviews by tuning a pretrained on IMDB model
+# Generates positive movie reviews by tuning a pretrained model on IMDB dataset
 # with a sentiment reward function
 
 from datasets import load_dataset
 from transformers import pipeline
+import os
 
 import trlx
+import torch
+from typing import List
 
-if __name__ == "__main__":
-    sentiment_fn = pipeline("sentiment-analysis", "lvwerra/distilbert-imdb", device=-1)
 
-    def reward_fn(samples):
-        outputs = sentiment_fn(samples, return_all_scores=True)
-        sentiments = [output[1]["score"] for output in outputs]
+def get_positive_score(scores):
+    "Extract value associated with a positive sentiment from pipeline's output"
+    return dict(map(lambda x: tuple(x.values()), scores))["POSITIVE"]
+
+
+def main():
+    if torch.cuda.is_available():
+        device = int(os.environ.get("LOCAL_RANK", 0))
+    else:
+        device = -1
+
+    sentiment_fn = pipeline(
+        "sentiment-analysis",
+        "lvwerra/distilbert-imdb",
+        top_k=2,
+        truncation=True,
+        device=device,
+    )
+
+    def reward_fn(samples: List[str]) -> List[float]:
+        sentiments = list(map(get_positive_score, sentiment_fn(samples)))
         return sentiments
 
     # Take few words off of movies reviews as prompts
@@ -24,3 +43,7 @@ if __name__ == "__main__":
         prompts=prompts,
         eval_prompts=["I don't know much about Hungarian underground"] * 64,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR
- truncates input into pipeline to bert's context length (512)
- puts pipeline on processes' local gpus for 2x speedup in training on single gpu (1:02 v 2:19 for 128 gradient steps), a bit more on multigpu (1:07 v 9:26 on 8 gpus) at cost of 0.5G extra VRAM
- removes depreciation warning of `return_all_scores` usage in pipeline, on transformers version `4.24.0`
