### PR TITLE
Refactor PPO objective function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 # This should be the _latest_ version of python supported by us
 default_language_version:
-  python: python3.8
+  python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 # This should be the _latest_ version of python supported by us
 default_language_version:
-  python: python3.9
+  python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/trlx/data/method_configs.py
+++ b/trlx/data/method_configs.py
@@ -58,60 +58,6 @@ class MethodConfig:
 
 @dataclass
 @register_method
-class PPOConfig(MethodConfig):
-    """
-    Config for PPO method
-
-    :param ppo_epochs: Number of updates per batch
-    :type ppo_epochs: int
-
-    :param num_rollouts: Number  of experiences to observe before learning
-    :type num_rollouts: int
-
-    :param init_kl_coef: Initial value for KL coefficient
-    :type init_kl_coef: float
-
-    :param target: Target value for KL coefficient
-    :type target: float
-
-    :param horizon: Number of steps for KL coefficient to reach target
-    :type horizon: int
-
-    :param gamma: Discount factor
-    :type gamma: float
-
-    :param lam: GAE lambda
-    :type lam: float
-
-    :param cliprange: Clipping range for PPO policy loss (1 - cliprange, 1 + cliprange)
-    :type cliprange: float
-
-    :param cliprange_value: Clipping range for predicted values (observed values - cliprange_value, observed values + cliprange_value)
-    :type cliprange_value: float
-
-    :param vf_coef: Value loss scale w.r.t policy loss
-    :type vf_coef: float
-
-    :param gen_kwargs: Additioanl kwargs for the generation
-    :type gen_kwargs: Dict[str, Any]
-    """
-
-    ppo_epochs: int
-    num_rollouts: int
-    chunk_size: int
-    init_kl_coef: float
-    target: float
-    horizon: int
-    gamma: float
-    lam: float
-    cliprange: float
-    cliprange_value: float
-    vf_coef: float
-    gen_kwargs: dict
-
-
-@dataclass
-@register_method
 class ILQLConfig(MethodConfig):
     """
     Config for ILQL method

--- a/trlx/model/accelerate_ppo_model.py
+++ b/trlx/model/accelerate_ppo_model.py
@@ -1,35 +1,19 @@
-import numpy as np
+from typing import Tuple
+
 import torch
+from torchtyping import TensorType
 
 from trlx.data.configs import TRLConfig
+from trlx.data.ppo_types import PPORLBatch
 from trlx.model import register_model
 from trlx.model.accelerate_base_model import AccelerateRLModel
-from trlx.model.nn.ppo_models import GPTHydraHeadWithValueModel
+from trlx.model.nn.ppo_models import (
+    AdaptiveKLController,
+    FixedKLController,
+    GPTHydraHeadWithValueModel,
+)
 from trlx.pipeline.ppo_pipeline import PPORolloutStorage
-from trlx.utils.modeling import clip_by_value, logprobs_from_logits, whiten
-
-
-class AdaptiveKLController:
-    def __init__(self, init_kl_coef, target, horizon):
-        self.value = init_kl_coef
-        self.target = target
-        self.horizon = horizon
-
-    def update(self, current, n_steps):
-        target = self.target
-        proportional_error = np.clip(current / target - 1, -0.2, 0.2)
-        mult = 1 + proportional_error * n_steps / self.horizon
-        self.value *= mult
-
-
-class FixedKLController:
-    """Fixed KL controller."""
-
-    def __init__(self, kl_coef):
-        self.value = kl_coef
-
-    def update(self, current, n_steps):
-        pass
+from trlx.utils.modeling import logprobs_from_logits
 
 
 @register_model
@@ -55,13 +39,6 @@ class AcceleratePPOModel(AccelerateRLModel):
         else:
             self.kl_ctl = FixedKLController(config.method.init_kl_coef)
 
-        if config.method.target is not None:
-            self.kl_ctl = AdaptiveKLController(
-                config.method.init_kl_coef, config.method.target, config.method.horizon
-            )
-        else:
-            self.kl_ctl = FixedKLController(config.method.init_kl_coef)
-
         self.generate_kwargs = dict(
             config.method.gen_kwargs,
             eos_token_id=self.tokenizer.eos_token_id,
@@ -73,85 +50,57 @@ class AcceleratePPOModel(AccelerateRLModel):
             self.config.model.model_path, self.config.model.num_layers_unfrozen
         )
 
-    def loss(self, batch):
-        query_tensors = batch.query_tensors.to(self.accelerator.device)
-        response_tensors = batch.response_tensors.to(self.accelerator.device)
-        all_logprobs = batch.logprobs.to(self.accelerator.device)
-        all_values = batch.values.to(self.accelerator.device)
-        all_rewards = batch.rewards.to(self.accelerator.device)
-
-        lastgaelam = 0
-        advantages_reversed = []
-        gen_len = response_tensors.shape[1]
-        for t in reversed(range(gen_len)):
-            nextvalues = all_values[:, t + 1] if t < gen_len - 1 else 0.0
-            delta = (
-                all_rewards[:, t]
-                + self.config.method.gamma * nextvalues
-                - all_values[:, t]
-            )
-            lastgaelam = (
-                delta + self.config.method.gamma * self.config.method.lam * lastgaelam
-            )
-            advantages_reversed.append(lastgaelam)
-        advantages = torch.stack(advantages_reversed[::-1]).transpose(0, 1)
-
-        returns = advantages + all_values
-        advantages = whiten(advantages)
-        advantages = advantages.detach()
-
-        all_tokens = torch.cat((query_tensors, response_tensors), dim=1)
+    def get_model_inputs(
+        self,
+        query_tensors: TensorType["batch_size", "query_size"],
+        response_tensors: TensorType["batch_size", "response_size"],
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        tokens = torch.cat((query_tensors, response_tensors), dim=1)
         attention_mask = (
-            all_tokens.not_equal(self.tokenizer.pad_token_id)
-            .long()
-            .to(all_tokens.device)
+            tokens.not_equal(self.tokenizer.pad_token_id).long().to(tokens.device)
         )
-
-        # for a proper positional encoding in case of left padding
+        # For a proper positional encoding in case of left padding
         position_ids = attention_mask.cumsum(-1) - 1
         position_ids.masked_fill_(attention_mask.eq(0), 0)
+        return tokens, attention_mask, position_ids
 
-        logits, _, vpred = self.model(
-            all_tokens, attention_mask, position_ids=position_ids
-        )
-        logprob = logprobs_from_logits(logits[:, :-1, :], all_tokens[:, 1:])
+    def loss(self, batch: PPORLBatch):
+        # Move `batch` data to `accelerator` device
+        query_tensors = batch.query_tensors.to(self.accelerator.device)
+        response_tensors = batch.response_tensors.to(self.accelerator.device)
+        old_logprobs = batch.logprobs.to(self.accelerator.device)
+        old_values = batch.values.to(self.accelerator.device)
+        old_rewards = batch.rewards.to(self.accelerator.device)
 
-        # only the generation part of the values/logprobs is needed
-        logprob, vpred = logprob[:, -gen_len:], vpred[:, -gen_len:]
-
-        vpredclipped = clip_by_value(
-            vpred,
-            all_values - self.config.method.cliprange_value,
-            all_values + self.config.method.cliprange_value,
-        )
-
-        mask = attention_mask[:, -gen_len:]
-
-        vf_losses1 = (vpred - returns) ** 2
-        vf_losses2 = (vpredclipped - returns) ** 2
-        vf_loss = 0.5 * torch.sum(torch.max(vf_losses1, vf_losses2) * mask) / mask.sum()
-
-        kl = logprob - all_logprobs
-        # Record mean_kl for kl coef adjustment
-        self.mean_kl = torch.mean(torch.sum(kl, dim=-1)).item()
-        ratio = torch.exp(kl)
-
-        pg_losses = -advantages * ratio
-        pg_losses2 = -advantages * torch.clamp(
-            ratio,
-            1.0 - self.config.method.cliprange,
-            1.0 + self.config.method.cliprange,
+        response_length = response_tensors.shape[-1]
+        advantages, returns = self.config.method.get_advantages_and_returns(
+            old_values, old_rewards, response_length
         )
 
-        pg_loss = torch.sum(torch.max(pg_losses, pg_losses2) * mask) / mask.sum()
-        loss = pg_loss + self.config.method.vf_coef * vf_loss
+        tokens, attention_mask, position_ids = self.get_model_inputs(
+            query_tensors, response_tensors
+        )
+        logits, _, values_pred = self.model(
+            tokens, attention_mask, position_ids=position_ids
+        )
+        logprobs = logprobs_from_logits(logits[:, :-1, :], tokens[:, 1:])
+        # Only the response part of the values/logprobs is needed
+        logprobs, values_pred, mask = (
+            logprobs[:, -response_length:],
+            values_pred[:, -response_length:],
+            attention_mask[:, -response_length:],
+        )
 
-        stats = {
-            "loss": loss,
-            "pg_loss": pg_loss,
-            "vf_loss": vf_loss,
-        }
-
+        loss, stats = self.config.method.loss(
+            logprobs=logprobs,
+            values=values_pred,
+            old_logprobs=old_logprobs,
+            old_values=old_values,
+            advantages=advantages,
+            returns=returns,
+            mask=mask,
+        )
+        self.approx_kl = stats["policy/approx_kl"]  # Update kl controller stats
         return loss, stats
 
     def post_epoch_callback(self):
@@ -161,8 +110,7 @@ class AcceleratePPOModel(AccelerateRLModel):
         )  # Collect more rollouts for training
 
     def post_backward_callback(self):
-        # Update kl_coefficient
-        self.kl_ctl.update(self.mean_kl, self.config.train.batch_size)
+        self.kl_ctl.update(self.approx_kl, n_steps=self.config.train.batch_size)
 
     def prepare_learning(self):
         eval_dataloader = self.eval_pipeline.create_loader(self.config.train.batch_size)


### PR DESCRIPTION
This PR decouples the PPO loss function from the `AcceleratePPOModel` class for general reuse following @cat-state 's work in #75 . The following updates are also provided:

- Adds the unbiased KL-div estimates following http://joschu.net/blog/kl-approx.html
    - Related Issue: #53 
- Removes repeated initialization of `self.kl_ctl` in `accelerate_ppo_models` constructor.
- Removes `utils.modeling.clip_by_value` as this functionality was added to PyTorch nearly 2 years ago.
- Introduces more PPO statistics to the logger for greater debugging information.

Test Run: https://wandb.ai/jon-tow/ppo-test
