### PR TITLE
Increase default eval interval

### DIFF
--- a/configs/ilql_config.yml
+++ b/configs/ilql_config.yml
@@ -17,7 +17,7 @@ train:
   weight_decay: 1.0e-6
 
   checkpoint_interval: 1000
-  eval_interval: 16
+  eval_interval: 256
 
   pipeline : "OfflinePipeline"
   orchestrator : "OfflineOrchestrator"

--- a/configs/ilql_config.yml
+++ b/configs/ilql_config.yml
@@ -17,7 +17,7 @@ train:
   weight_decay: 1.0e-6
 
   checkpoint_interval: 1000
-  eval_interval: 256
+  eval_interval: 64
 
   pipeline : "OfflinePipeline"
   orchestrator : "OfflineOrchestrator"


### PR DESCRIPTION
Much faster training - ~20 min instead of >1 hour. This is in units of train_steps
https://wandb.ai/carperai/trlx/runs/3gkbitl7