### PR TITLE
Fix slow ilql eval

### DIFF
--- a/configs/ilql_config.yml
+++ b/configs/ilql_config.yml
@@ -7,7 +7,7 @@ model:
 train:
   seq_length: 64
   batch_size: 128
-  epochs: 10
+  epochs: 100
   total_steps: 10000
 
   lr_init: 1.0e-4
@@ -17,7 +17,7 @@ train:
   weight_decay: 1.0e-6
 
   checkpoint_interval: 1000
-  eval_interval: 16
+  eval_interval: 128
 
   pipeline : "OfflinePipeline"
   orchestrator : "OfflineOrchestrator"

--- a/examples/ilql_sentiments.py
+++ b/examples/ilql_sentiments.py
@@ -5,6 +5,7 @@ from transformers import pipeline
 
 import trlx
 from typing import List, Dict
+import os
 
 
 def get_positive_score(scores):
@@ -19,7 +20,7 @@ def main():
         top_k=2,
         truncation=True,
         batch_size=256,
-        device=-1,
+        device=0 if int(os.environ.get("LOCAL_RANK", 0)) == 0 else -1,
     )
 
     def metric_fn(samples: List[str]) -> Dict[str, List[float]]:

--- a/trlx/model/nn/ilql_models.py
+++ b/trlx/model/nn/ilql_models.py
@@ -170,7 +170,6 @@ class CausalLMWithValueHeads(nn.Module):
         temperature=1,
         top_k=20,
         logit_mask=None,
-        logs=True,
         pad_token_id=50256,
         eos_token_id=50256,
     ):
@@ -226,29 +225,10 @@ class CausalLMWithValueHeads(nn.Module):
             )
             position_ids = (position_ids[:, -1] + 1).view(-1, 1)
 
-            if logs:
-                tensors["qs"].append(qs)
-                tensors["vs"].append(vs)
-                tensors["adv"].append(adv)
-                tensors["pi"].append(pi)
-
             if torch.all(finished):
                 break
 
-        stats = {}
-        for name, xs in tensors.items():
-            xs = torch.vstack(xs)
-            xs = torch.where(torch.isfinite(xs), xs, 0)
-
-            stats.update(
-                {
-                    f"tensors/{name}/{beta}": wandb.Histogram(
-                        xs.cpu().float().view(-1)
-                    ),
-                }
-            )
-
-        return samples, stats
+        return samples
 
     @property
     def dummy_inputs(self):


### PR DESCRIPTION
This pr
- puts pipeline on rank 0 gpu to process large validation batch sizes
- removes stats collection with `wandb.Histogram` during sampling, since it was redundant and also was slowing down validation

https://wandb.ai/sorry/public/runs/1u2vv56a