### PR TITLE
Update README to align nomenclature correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # Transformer Reinforcement Learning X
 
-trLX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo` and `gpt-neox` based) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
+trlX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo` and `gpt-neox` based) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
 
-You can read more about trLX in our [documentation](https://trlX.readthedocs.io).
+You can read more about trlX in our [documentation](https://trlX.readthedocs.io).
 
 ## Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # Transformer Reinforcement Learning X
 
-TRLX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo` and `gpt-neox` based) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
+trLX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo` and `gpt-neox` based) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
 
-You can read more about TRLX in our [documentation](https://trlX.readthedocs.io).
+You can read more about trLX in our [documentation](https://trlX.readthedocs.io).
 
 ## Installation
 ```bash


### PR DESCRIPTION
The documentation for this library uses trLX instead of TRLX as the naming scheme. This PR updates the README to reflect the same.

<img width="757" alt="image" src="https://user-images.githubusercontent.com/31141479/202390162-0c1b0d43-898d-407f-b773-e622a43d80f2.png">
