### PR TITLE
Fix ppo ratio inaccuracy

### DIFF
--- a/configs/ppo_config.yml
+++ b/configs/ppo_config.yml
@@ -21,7 +21,6 @@ train:
 
   pipeline: "PromptPipeline"  # prompt pipeline to load
   orchestrator: "PPOOrchestrator"  # orchestrator to load
-  entity_name: "jon-tow"
 
 method:
   name: 'ppoconfig'  # Name of RL method config

--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -23,7 +23,7 @@ else:
 import ray
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
-from trlx.utils import filter_non_scalars
+from trlx.utils import filter_non_scalars, get_git_tag
 
 
 @register_model
@@ -85,6 +85,7 @@ class AccelerateRLModel(BaseRLModel):
                     "wandb": {
                         "name": run_name,
                         "entity": self.config.train.entity_name,
+                        "tags": [get_git_tag()],
                         "mode": "disabled"
                         if os.environ.get("debug", False)
                         else "online",
@@ -238,7 +239,7 @@ class AccelerateRLModel(BaseRLModel):
                         self.iter_count = state["iter_count"]
         else:
             results = self.evaluate()
-            self.accelerator.log(results)
+            self.accelerator.log(results, step=self.iter_count)
 
         tbar = tqdm(
             initial=self.iter_count,
@@ -265,19 +266,12 @@ class AccelerateRLModel(BaseRLModel):
                     if self.iter_count % self.config.train.checkpoint_interval == 0:
                         self.save()
 
+                    stats["forward_time"] = forward_time
+                    stats["backward_time"] = backward_time
+
                     if self.iter_count % self.config.train.eval_interval == 0:
                         results = self.evaluate()
-
-                        results.update(stats)
-                        results.update(
-                            {
-                                "forward_time": forward_time,
-                                "backward_time": backward_time,
-                            }
-                        )
-
-                        if not ray.is_initialized():
-                            self.accelerator.log(results)
+                        stats.update(results)
 
                         # Report the metrics to Ray Tune.
                         if ray.is_initialized():
@@ -286,10 +280,17 @@ class AccelerateRLModel(BaseRLModel):
                                 json.dump(dict(iter_count=self.iter_count), f)
                             checkpoint = Checkpoint.from_directory("state")
                             session.report(
-                                filter_non_scalars(results), checkpoint=checkpoint
+                                filter_non_scalars(stats), checkpoint=checkpoint
                             )
 
-                    desc = ", ".join(f"{k}: {v:.2f}" for k, v in stats.items())
+                    if not ray.is_initialized():
+                        self.accelerator.log(stats, step=self.iter_count)
+
+                    desc = ", ".join(
+                        f"{k}: {v:.2f}"
+                        for k, v in stats.items()
+                        if k.startswith("loss")
+                    )
                     tbar.set_description(desc)
                     tbar.update()
 

--- a/trlx/model/nn/ppo_models.py
+++ b/trlx/model/nn/ppo_models.py
@@ -193,6 +193,7 @@ class PPOConfig(MethodConfig):
             ),
             policy=dict(approx_kl=approx_kl.item(), clipfrac=pg_clipfrac.item()),
             returns=dict(mean=torch.mean(returns), var=torch.var(returns)),
+            ratio=(ratio * mask).sum() / mask.sum(),
         )
         return loss, flatten_dict(stats)
 

--- a/trlx/model/nn/ppo_models.py
+++ b/trlx/model/nn/ppo_models.py
@@ -161,7 +161,7 @@ class PPOConfig(MethodConfig):
         vf_loss = 0.5 * torch.sum(torch.max(vf_loss1, vf_loss2) * mask) / mask.sum()
         vf_clipfrac = torch.mean((vf_loss2 > vf_loss1).float())
 
-        log_ratio = logprobs - old_logprobs
+        log_ratio = (logprobs - old_logprobs) * mask
         ratio = torch.exp(log_ratio)
         # Unbiased KL-div estimates (`k3`). Ref: http://joschu.net/blog/kl-approx.html
         with torch.no_grad():

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -102,18 +102,27 @@ class PPOOrchestrator(Orchestrator):
                 scores = torch.clip(scores, -clip_reward, clip_reward)
 
             # Precompute logprobs, values
-            all_tokens = torch.cat(
-                (query_tensors.to(samples.device), response_tensors), dim=1
+            all_tokens, attention_mask, position_ids = self.rl_model.get_model_inputs(
+                query_tensors, response_tensors
             )
             with torch.no_grad():
-                logits, _, v = self.rl_model.model(all_tokens)
+                logits, _, v = self.rl_model.model(
+                    all_tokens, attention_mask, position_ids=position_ids
+                )
                 # TODO(dahoas): When hydra model works need to also support generation on hydra head
                 if hasattr(self.rl_model.model, "frozen_head"):
                     ref_logits = self.rl_model.model.forward_hydra(
-                        all_tokens, return_dict=False
+                        all_tokens,
+                        attention_mask=attention_mask,
+                        position_ids=position_ids,
+                        return_dict=False,
                     )
                 else:
-                    ref_logits, _, _ = self.ref_model(all_tokens.cpu())
+                    ref_logits, _, _ = self.ref_model(
+                        all_tokens.cpu(),
+                        attention_mask.cpu(),
+                        position_ids=position_ids.cpu(),
+                    )
 
             ref_logits = ref_logits.to(self.rl_model.accelerator.device)
             logprobs = logprobs_from_logits(logits[:, :-1, :], all_tokens[:, 1:])

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -3,6 +3,7 @@ import time
 from functools import reduce
 from typing import Any, Iterable, List, Dict
 from dataclasses import is_dataclass
+import subprocess
 
 import numpy as np
 import torch
@@ -150,3 +151,11 @@ def filter_non_scalars(xs: Dict) -> Dict:
             continue
 
     return ys
+
+
+def get_git_tag() -> str:
+    """
+    Returns commit's short hash and date
+    """
+    output = subprocess.check_output("git log --format='%h/%as' -n1".split())
+    return output.decode()[1:-2]


### PR DESCRIPTION
This pr fixes #107 
- lets models in orchestrator use `attention_mask` for computing `old_logprobs`

but also
- removes entity_name from ppo_config (which I suspect wasn't intentional)
- enables more thorough logging, synced with orchestrator's logging with `iter_count`
- adds git commit as tag to wandb runs

https://wandb.ai/sorry/public/reports/Ratio-fix--VmlldzozMDE4NzI2