### PR TITLE
Set RNG seeds across multiple dependencies

### DIFF
--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -39,8 +39,6 @@ class AccelerateRLModel(BaseRLModel):
 
         if int(os.environ.get("WORLD_SIZE", 1)) > 1:
             torch.distributed.barrier(device_ids=[int(os.environ.get("LOCAL_RANK", 0))])
-        else:
-            torch.random.manual_seed(config.train.seed)
 
         # Retrieves model equipped for ppo, ilql, etc
         self.model = self.get_arch(self.config)

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -2,6 +2,7 @@ import os
 from typing import Callable, Iterable, List, Optional, Tuple
 
 from trlx.data.configs import TRLConfig
+from trlx.utils import set_seed
 from trlx.utils.loading import get_model, get_orchestrator, get_pipeline
 
 
@@ -30,7 +31,7 @@ def train(
         split_token (Optional[str]): Split samples in the dataset on prompts and continuations
         logit_mask (Optional[List]): Bigram masking matrix
     """
-
+    set_seed(config.train.seed)
     if reward_fn is not None:
         if config is None:
             config = TRLConfig.load_yaml("configs/ppo_config.yml")

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -1,4 +1,5 @@
 import os
+import random
 import time
 from functools import reduce
 from typing import Any, Iterable, List, Dict
@@ -9,6 +10,16 @@ import numpy as np
 import torch
 from torch.optim.lr_scheduler import ChainedScheduler, LinearLR
 from torchtyping import TensorType
+
+
+def set_seed(seed: int):
+    """
+    Sets seeds across package dependencies for reproducibility.
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
 
 
 def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:


### PR DESCRIPTION
This PR adds RNG seeding across multiple dependencies to improve reproducible behavior. Previously, seeding was only configured through `torch.random.manual_seed` leading to variable runs between experiments with the same configuration.

* `wandb` logs: https://wandb.ai/jon-tow/trlx-seed/reports/branch-fix-seeding--VmlldzozMDQwOTU3?accessToken=9jbh76n9ur7khpdouyvftzo267gqd051k2z64mcej6cnhsuji921max2ee8d2952