### PR TITLE
Add local rollout logging

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -98,6 +98,9 @@ class TrainConfig:
 
     :param entity_name: Entity name for wandb
     :type entity_name: str
+    
+    :param rollout_logging_dir: Directory to store generated rollouts for use in Algorithm Distillation. Only used by AcceleratePPOModel.
+    :type rollout_logging_dir: Optional[str]
     """
 
     total_steps: int
@@ -113,6 +116,7 @@ class TrainConfig:
 
     checkpoint_interval: int
     eval_interval: int
+    
 
     pipeline: str  # One of the pipelines in framework.pipeline
     orchestrator: str  # One of the orchestrators
@@ -121,6 +125,8 @@ class TrainConfig:
     project_name: str = "trlx"
     entity_name: Optional[str] = None
     seed: int = 1000
+    
+    rollout_logging_dir: Optional[str] = None
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -98,7 +98,7 @@ class TrainConfig:
 
     :param entity_name: Entity name for wandb
     :type entity_name: str
-    
+
     :param rollout_logging_dir: Directory to store generated rollouts for use in Algorithm Distillation. Only used by AcceleratePPOModel.
     :type rollout_logging_dir: Optional[str]
     """
@@ -116,7 +116,6 @@ class TrainConfig:
 
     checkpoint_interval: int
     eval_interval: int
-    
 
     pipeline: str  # One of the pipelines in framework.pipeline
     orchestrator: str  # One of the orchestrators
@@ -125,7 +124,7 @@ class TrainConfig:
     project_name: str = "trlx"
     entity_name: Optional[str] = None
     seed: int = 1000
-    
+
     rollout_logging_dir: Optional[str] = None
 
     @classmethod

--- a/trlx/model/accelerate_ppo_model.py
+++ b/trlx/model/accelerate_ppo_model.py
@@ -21,13 +21,13 @@ from trlx.utils.modeling import logprobs_from_logits
 class AcceleratePPOModel(AccelerateRLModel):
     def __init__(self, config):
         super().__init__(config)
-        
+
         if config.train.rollout_logging_dir is not None:
             self.log_rollouts = True
             self.setup_rollout_logging(config)
         else:
             self.log_rollouts = False
-        
+
         self.store = PPORolloutStorage(self.tokenizer.pad_token_id)
 
         rollout_loader = self.store.create_loader(
@@ -109,18 +109,20 @@ class AcceleratePPOModel(AccelerateRLModel):
         )
         self.approx_kl = stats["policy/approx_kl"]  # Update kl controller stats
         return loss, stats
-    
+
     def setup_rollout_logging(self, config):
         # Make rollout logging dir for this run and store config
         exists = os.path.exists(config.train.rollout_logging_dir)
         isdir = os.path.isdir(config.train.rollout_logging_dir)
         assert exists and isdir
-        
-        self.run_id = f'run-{uuid.uuid4()}'
-        self.rollout_logging_dir = os.path.join(config.train.rollout_logging_dir, self.run_id)
+
+        self.run_id = f"run-{uuid.uuid4()}"
+        self.rollout_logging_dir = os.path.join(
+            config.train.rollout_logging_dir, self.run_id
+        )
         os.mkdir(self.rollout_logging_dir)
-        
-        with open(os.path.join(self.rollout_logging_dir, 'config.json'), 'w') as f:
+
+        with open(os.path.join(self.rollout_logging_dir, "config.json"), "w") as f:
             f.write(json.dumps(config.to_dict(), indent=2))
 
     def post_epoch_callback(self):

--- a/trlx/pipeline/ppo_pipeline.py
+++ b/trlx/pipeline/ppo_pipeline.py
@@ -26,16 +26,15 @@ class PPORolloutStorage(BaseRolloutStore):
 
     def clear_history(self):
         self.history = []
-        
+
     def export_history(self, location: str):
         assert os.path.exists(location)
 
-        fpath = os.path.join(location, f'epoch-{str(time.time())}.json')
-        exp_to_dict = lambda exp : {k:v.cpu().tolist() for k,v in exp.__dict__.items()}
+        fpath = os.path.join(location, f"epoch-{str(time.time())}.json")
+        exp_to_dict = lambda exp: {k: v.cpu().tolist() for k, v in exp.__dict__.items()}
         data = [exp_to_dict(exp) for exp in self.history]
-        with open(fpath, 'w') as f:
+        with open(fpath, "w") as f:
             f.write(json.dumps(data, indent=2))
-        
 
     def __getitem__(self, index: int) -> PPORLElement:
         return self.history[index]

--- a/trlx/pipeline/ppo_pipeline.py
+++ b/trlx/pipeline/ppo_pipeline.py
@@ -1,4 +1,6 @@
-from typing import Iterable
+import os, json, time
+
+from typing import Iterable, Optional
 
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
@@ -24,6 +26,16 @@ class PPORolloutStorage(BaseRolloutStore):
 
     def clear_history(self):
         self.history = []
+        
+    def export_history(self, location: str):
+        assert os.path.exists(location)
+
+        fpath = os.path.join(location, f'epoch-{str(time.time())}.json')
+        exp_to_dict = lambda exp : {k:v.cpu().tolist() for k,v in exp.__dict__.items()}
+        data = [exp_to_dict(exp) for exp in self.history]
+        with open(fpath, 'w') as f:
+            f.write(json.dumps(data, indent=2))
+        
 
     def __getitem__(self, index: int) -> PPORLElement:
         return self.history[index]


### PR DESCRIPTION
Adds the `rollout_logging_dir` parameter to `TrainConfig`, which when specified will triggering the saving generated rollouts at the end of each epoch.

See the relevant pull request in [algorithm distillation](project) to see how this can be used to collect rollouts over a hyperparameter sweep.

In future we should probably extend this to log to wandb artifacts.