### PR TITLE
Add hydra head support for `GPTNeo`

### DIFF
--- a/trlx/model/nn/ppo_models.py
+++ b/trlx/model/nn/ppo_models.py
@@ -805,6 +805,7 @@ def hf_get_causal_lm_branch_class(
     gpt_branch_supported_archs = [
         "GPTJForCausalLM",
         "GPT2LMHeadModel",
+        "GPTNeoForCausalLM",
         "GPTNeoXForCausalLM",
     ]
     opt_branch_supported_archs = ["OPTForCausalLM"]


### PR DESCRIPTION
This PR adds `GPTNeo`-based hydra heads for complete support of the EleutherAI model suite.

_Note_: `GPTNeo` follows the same model branch implementation as `GPTModelBranch` so there are no source changes.

`wandb` reports:
* [PPO sentiment](https://wandb.ai/jon-tow/trlx/reports/trlx-GPT-Neo-PPO-Sentiment---VmlldzozMDkxNzY2?accessToken=944j2mf4827ww9dudiktf7xb8yrzftnp20oip2nxftev9jxc9dsmwkadf9sw90cd)
* [ILQL sentiment](https://wandb.ai/jon-tow/trlx/reports/trlx-GPT-Neo-PPO-Sentiment--VmlldzozMDkxNzg4?accessToken=p7vk9yti9rf52futwyixu8847pz96z0rv01ilksi8dy7hta2qr319f5xjwrr9s51)