### PR TITLE
Add `OptimizerConfig` and `SchedulerConfig`

### DIFF
--- a/configs/ilql_config.yml
+++ b/configs/ilql_config.yml
@@ -1,27 +1,36 @@
-model:
-  model_path: "gpt2"
-  tokenizer_path: "gpt2"
-  model_type: "AccelerateILQLModel"
-  num_layers_unfrozen: -1
-
 train:
   seq_length: 64
   batch_size: 128
   epochs: 100
   total_steps: 1000
 
-  lr_init: 5.0e-5
-  lr_target: 5.0e-5
-  opt_betas: [0.9, 0.95]
-  opt_eps: 1.0e-8
-  weight_decay: 1.0e-6
-
   checkpoint_interval: 1000
   eval_interval: 100
 
   pipeline: "PromptPipeline"
   orchestrator: "OfflineOrchestrator"
+
   seed: 1000
+
+model:
+  model_type: "AccelerateILQLModel"
+  model_path: "gpt2"
+  tokenizer_path: "gpt2"
+  num_layers_unfrozen: -1
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 5.0e-5
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 1000 # train.total_steps
+    eta_min: 5.0e-5
 
 method:
   name: "ilqlconfig"

--- a/configs/ppo_config.yml
+++ b/configs/ppo_config.yml
@@ -1,47 +1,56 @@
-model:
-  model_path: "lvwerra/gpt2-imdb"  # Name of hf model to load
-  tokenizer_path: "gpt2"  # Name of hf tokenizer to load
-  model_type: "AcceleratePPOModel"  # Name of accelerate model type to load
-  num_layers_unfrozen: 2  # Number of bottom layers to freeze during training
-
 train:
-  seq_length: 48  # Size of LM context
-  epochs: 100 # Train for max(epochs, total_steps)
-  total_steps: 10000  # Train for max(epochs, total_steps)
-  batch_size: 128  # batch size
+  seq_length: 48
+  epochs: 100
+  total_steps: 10000
+  batch_size: 128
 
-  lr_init: 1.0e-4  # init learning rate
-  lr_target: 1.0e-4  # target final learning rate
-  opt_betas: [0.9, 0.95] # adam betas
-  opt_eps: 1.0e-8  # adam eps
-  weight_decay: 1.0e-6  # weight decay param
+  checkpoint_interval: 10000
+  eval_interval: 100
 
-  checkpoint_interval: 10000  # checkpoint interval
-  eval_interval: 100  # eval interval
+  pipeline: "PromptPipeline"
+  orchestrator: "PPOOrchestrator"
+  entity_name: "jon-tow"
 
-  pipeline: "PromptPipeline"  # prompt pipeline to load
-  orchestrator: "PPOOrchestrator"  # orchestrator to load
+model:
+  model_type: "AcceleratePPOModel"
+  model_path: "lvwerra/gpt2-imdb"
+  tokenizer_path: "gpt2"
+  num_layers_unfrozen: 2
+
+optimizer:
+  name: "adam"
+  kwargs:
+    lr: 1.0e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 10000 # train.total_steps
+    eta_min: 1.0e-4
 
 method:
-  name: 'ppoconfig'  # Name of RL method config
-  num_rollouts: 128  # Number of rollouts to collect per epoch
-  chunk_size: 128  # Number of rollouts to collect in one loop of orchestrator
-  ppo_epochs: 4  # Number of ppo epochs
-  init_kl_coef: 0.05  # init kl coefficient
-  target: 6  # target kl coefficient, set None for fixed kl coef
-  horizon: 10000  # PPO horizon
-  gamma: 1  # PPO discount
-  lam: 0.95  # PPO lambda
-  cliprange: 0.2  # clip range
-  cliprange_value: 0.2  # clip range
-  vf_coef: 1  # value term weight
-  scale_reward: False # False | "ref" | "running" estimate against which to scale rewards
+  name: "ppoconfig"
+  num_rollouts: 128
+  chunk_size: 128
+  ppo_epochs: 4
+  init_kl_coef: 0.05
+  target: 6
+  horizon: 10000
+  gamma: 1
+  lam: 0.95
+  cliprange: 0.2
+  cliprange_value: 0.2
+  vf_coef: 1
+  scale_reward: False
   ref_mean: null
-  ref_std: null # rescale rewards with this deviation
+  ref_std: null
   cliprange_reward: 10
   gen_kwargs:
-    max_length: 48  # LM max sample gen length
-    min_length: 48  # LM min sample gen length
-    top_k: 0.0  # top k
-    top_p: 1.0  # top p
-    do_sample: True  # sample
+    max_length: 48
+    min_length: 48
+    top_k: 0.0
+    top_p: 1.0
+    do_sample: True

--- a/configs/ppo_gptj.yml
+++ b/configs/ppo_gptj.yml
@@ -1,48 +1,57 @@
-model:
-  model_path: "EleutherAI/gpt-j-6B"  # Name of hf model to load
-  tokenizer_path: "gpt2"  # Name of hf tokenizer to load
-  model_type: "AcceleratePPOModel"  # Name of accelerate model type to load
-  num_layers_unfrozen: 2  # Number of bottom layers to freeze during training
-
 train:
-  seq_length: 48  # Size of LM context
-  epochs: 10  # Train for max(epochs, total_steps)
-  total_steps: 80000  # Train for max(epochs, total_steps)
-  batch_size: 8  # batch size
+  seq_length: 48
+  epochs: 10
+  total_steps: 80000
+  batch_size: 8
 
-  lr_init: 1.412e-4  # init learning rate
-  lr_target: 1.412e-4  # target final learning rate
-  opt_betas: [0.9, 0.95] # adam betas
-  opt_eps: 1.0e-8  # adam eps
-  weight_decay: 1.0e-6  # weight decay param
+  checkpoint_interval: 1000000
+  eval_interval: 16
 
-  checkpoint_interval: 1000000  # checkpoint interval
-  eval_interval: 16  # eval interval
+  pipeline: "PromptPipeline"
+  orchestrator: "PPOOrchestrator"
+  entity_name: "jon-tow"
 
-  pipeline: "PromptPipeline"  # prompt pipeline to load
-  orchestrator: "PPOOrchestrator"  # orchestrator to load
+model:
+  model_type: "AcceleratePPOModel"
+  model_path: "EleutherAI/gpt-j-6B"
+  tokenizer_path: "gpt2"
+  num_layers_unfrozen: 2
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 1.412e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 80000 # train.total_steps
+    eta_min: 1.412e-4
 
 method:
-  name: 'ppoconfig'  # Name of RL method config
-  num_rollouts: 8  # Number of rollouts to collect per epoch
-  chunk_size: 8  # Number of rollouts to collect in one loop of orchestrator
-  ppo_epochs: 4  # Number of ppo epochs
-  init_kl_coef: 0.2  # init kl coefficient
-  target: 6  # target kl coefficient
-  horizon: 10000  # PPO horizon
-  gamma: 1  # PPO discount
-  lam: 0.95  # PPO lambda
-  cliprange: 0.2  # clip range
-  cliprange_value: 0.2  # clip range
-  vf_coef: 0.2  # value term weight
-  scale_reward: False # False | "ref" | "running" estimate against which to scale rewards
+  name: "ppoconfig"
+  num_rollouts: 8
+  chunk_size: 8
+  ppo_epochs: 4
+  init_kl_coef: 0.2
+  target: 6
+  horizon: 10000
+  gamma: 1
+  lam: 0.95
+  cliprange: 0.2
+  cliprange_value: 0.2
+  vf_coef: 0.2
+  scale_reward: False
   ref_mean: null
-  ref_std: null # rescale rewards with this deviation
+  ref_std: null
   cliprange_reward: 10
   gen_kwargs:
-    max_length: 48  # LM max sample gen length
-    min_length: 48  # LM min sample gen length
-    top_k: 0.0  # top k
-    top_p: 0.7  # top p
-    do_sample: True  # sample
+    max_length: 48
+    min_length: 48
+    top_k: 0.0
+    top_p: 0.7
+    do_sample: True
     temperature: 0.5

--- a/configs/test_config.yml
+++ b/configs/test_config.yml
@@ -1,47 +1,55 @@
-model:
-  model_path: "lvwerra/gpt2-imdb"  # Name of hf model to load
-  tokenizer_path: "gpt2"  # Name of hf tokenizer to load
-  model_type: "AcceleratePPOModel"  # Name of accelerate model type to load
-  num_layers_unfrozen: 2  # Number of bottom layers to freeze during training
-
 train:
-  seq_length: 64  # Size of LM context
-  epochs: 100  # Train for max(epochs, total_steps)
-  total_steps: 1000  # Train for max(epochs, total_steps)
-  batch_size: 16  # batch size
+  seq_length: 64 # Size of LM context
+  epochs: 100 # Train for max(epochs, total_steps)
+  total_steps: 1000 # Train for max(epochs, total_steps)
+  batch_size: 16 # batch size
 
-  lr_init: 1.412e-4  # init learning rate
-  lr_target: 1.412e-4  # target final learning rate
-  opt_betas: [0.9, 0.95] # adam betas
-  opt_eps: 1.0e-8  # adam eps
-  weight_decay: 1.0e-6  # weight decay param
+  checkpoint_interval: 10000 # checkpoint interval
+  eval_interval: 128 # eval interval
 
-  checkpoint_interval: 10000  # checkpoint interval
-  eval_interval: 128  # eval interval
+  pipeline: "PromptPipeline" # prompt pipeline to load
+  orchestrator: "PPOOrchestrator" # orchestrator to load
 
-  pipeline: "PromptPipeline"  # prompt pipeline to load
-  orchestrator: "PPOOrchestrator"  # orchestrator to load
+model:
+  model_type: "AcceleratePPOModel" # Name of accelerate model type to load
+  model_path: "lvwerra/gpt2-imdb" # Name of hf model to load
+  tokenizer_path: "gpt2" # Name of hf tokenizer to load
+  num_layers_unfrozen: 2 # Number of bottom layers to freeze during training
+
+optimizer:
+  name: "adamw" # Name of optimizer to load
+  kwargs:
+    lr: 1.412e-4 # Learning rate
+    betas: [0.9, 0.95] # Adam betas
+    eps: 1.0e-8 # Adam eps
+    weight_decay: 1.0e-6 # Weight decay param
+
+scheduler:
+  name: "cosine_annealing" # Name of learning rate scheduler
+  kwargs:
+    T_max: 10000 # Maximum number of steps
+    eta_min: 1.412e-4 # Minimum learning rate
 
 method:
-  name: 'ppoconfig'  # Name of RL method config
-  num_rollouts: 128  # Number of rollouts to collect per epoch
-  chunk_size: 128  # Number of rollouts to collect in one loop of orchestrator
-  ppo_epochs: 4  # Number of ppo epochs
-  init_kl_coef: 0.2  # init kl coefficient
-  target: 6  # target kl coefficient, set None for fixed kl coef
-  horizon: 10000  # PPO horizon
-  gamma: 0.99  # PPO discount
-  lam: 0.95  # PPO lambda
-  cliprange: 0.2  # clip range
-  cliprange_value: 0.2  # clip range
-  vf_coef: 1.0  # value term weight
+  name: "ppoconfig" # Name of RL method config
+  num_rollouts: 128 # Number of rollouts to collect per epoch
+  chunk_size: 128 # Number of rollouts to collect in one loop of orchestrator
+  ppo_epochs: 4 # Number of ppo epochs
+  init_kl_coef: 0.2 # init kl coefficient
+  target: 6 # target kl coefficient, set None for fixed kl coef
+  horizon: 10000 # PPO horizon
+  gamma: 0.99 # PPO discount
+  lam: 0.95 # PPO lambda
+  cliprange: 0.2 # clip range
+  cliprange_value: 0.2 # clip range
+  vf_coef: 1.0 # value term weight
   scale_reward: "running" # False|"ref"|"running" estimate against which to scale rewards
   cliprange_reward: 10
   ref_mean: null
   ref_std: null
   gen_kwargs:
-    max_length: 48  # LM max sample gen length
-    min_length: 48  # LM min sample gen length
-    top_k: 0.0  # top k
-    top_p: 1.0  # top p
-    do_sample: True  # sample
+    max_length: 48 # LM max sample gen length
+    min_length: 48 # LM min sample gen length
+    top_k: 0.0 # top k
+    top_p: 1.0 # top p
+    do_sample: True # sample

--- a/examples/experiments/grounded_program_synthesis/configs/trlx_ppo_config.yml
+++ b/examples/experiments/grounded_program_synthesis/configs/trlx_ppo_config.yml
@@ -1,48 +1,56 @@
-model:
-  model_path: "reshinthadith/codegen_350M_list_manip_5_len"  # Name of hf model to load
-  tokenizer_path: "reshinthadith/codegen_350M_list_manip_5_len"  # Name of hf tokenizer to load
-  model_type: "AcceleratePPOModel"  # Name of accelerate model type to load
-  num_layers_unfrozen: 2  # Number of bottom layers to freeze during training
-
 train:
-  seq_length: 256  # Size of LM context
-  epochs: 10  # Train for max(epochs, total_steps)
-  total_steps: 80000  # Train for max(epochs, total_steps)
-  batch_size: 8  # batch size
+  seq_length: 256
+  epochs: 10
+  total_steps: 80000
+  batch_size: 8
 
-  lr_init: 1.412e-4  # init learning rate
-  lr_target: 1.412e-4  # target final learning rate
-  opt_betas: [0.9, 0.95] # adam betas
-  opt_eps: 1.0e-8  # adam eps
-  weight_decay: 1.0e-6  # weight decay param
+  checkpoint_interval: 1000000
+  eval_interval: 16
 
-  checkpoint_interval: 1000000  # checkpoint interval
-  eval_interval: 16  # eval interval
+  pipeline: "PromptPipeline"
+  orchestrator: "PPOOrchestrator"
 
-  pipeline: "PromptPipeline"  # prompt pipeline to load
-  orchestrator: "PPOOrchestrator"  # orchestrator to load
+model:
+  model_type: "AcceleratePPOModel"
+  model_path: "reshinthadith/codegen_350M_list_manip_5_len"
+  tokenizer_path: "reshinthadith/codegen_350M_list_manip_5_len"
+  num_layers_unfrozen: 2
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 1.412e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 80000 # train.total_steps
+    eta_min: 1.412e-4
 
 method:
-  name: 'ppoconfig'  # Name of RL method config
-  num_rollouts: 8  # Number of rollouts to collect per epoch
-  chunk_size: 8  # Number of rollouts to collect in one loop of orchestrator
-  ppo_epochs: 4  # Number of ppo epochs
-  init_kl_coef: 0.2  # init kl coefficient
-  target: 6  # target kl coefficient
-  horizon: 10000  # PPO horizon
-  gamma: 1  # PPO discount
-  lam: 0.95  # PPO lambda
-  cliprange: 0.2  # clip range
-  cliprange_value: 0.2  # clip range
-  vf_coef: 0.2  # value term weight
-  scale_reward: False # False|"ref"|"running" estimate against which to scale rewards
+  name: "ppoconfig"
+  num_rollouts: 8
+  chunk_size: 8
+  ppo_epochs: 4
+  init_kl_coef: 0.2
+  target: 6
+  horizon: 10000
+  gamma: 1
+  lam: 0.95
+  cliprange: 0.2
+  cliprange_value: 0.2
+  vf_coef: 0.2
+  scale_reward: False
   cliprange_reward: 10
   ref_mean: null
   ref_std: null
   gen_kwargs:
-    max_length: 256  # LM max sample gen length
-    min_length: 48  # LM min sample gen length
-    top_k: 0.0  # top k
-    top_p: 0.7  # top p
-    do_sample: True  # sample
+    max_length: 256
+    min_length: 48
+    top_k: 0.0
+    top_p: 0.7
+    do_sample: True
     temperature: 0.5

--- a/examples/randomwalks/configs/ilql_randomwalks.yml
+++ b/examples/randomwalks/configs/ilql_randomwalks.yml
@@ -1,27 +1,36 @@
-model:
-  model_path: "CarperAI/randomwalks"
-  tokenizer_path: "CarperAI/randomwalks"
-  model_type: "AccelerateILQLModel"
-  num_layers_unfrozen: -1
-
 train:
   seq_length: 10
   batch_size: 100
   epochs: 20
   total_steps: 1000
 
-  lr_init: 2.0e-4
-  lr_target: 2.0e-4
-  opt_betas: [0.9, 0.95]
-  opt_eps: 1.0e-8
-  weight_decay: 1.0e-6
-
   checkpoint_interval: 100000
   eval_interval: 16
 
   pipeline: "PromptPipeline"
   orchestrator: "OfflineOrchestrator"
+
   seed: 1000
+
+model:
+  model_type: "AccelerateILQLModel"
+  model_path: "CarperAI/randomwalks"
+  tokenizer_path: "CarperAI/randomwalks"
+  num_layers_unfrozen: -1
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 2.0e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 1000 # train.total_steps
+    eta_min: 2.0e-4
 
 method:
   name: "ilqlconfig"

--- a/examples/randomwalks/configs/ppo_randomwalks.yml
+++ b/examples/randomwalks/configs/ppo_randomwalks.yml
@@ -1,20 +1,8 @@
-model:
-  model_path: "CarperAI/randomwalks"
-  tokenizer_path: "CarperAI/randomwalks"
-  model_type: "AcceleratePPOModel"
-  num_layers_unfrozen: -1
-
 train:
   seq_length: 10
   batch_size: 100
   epochs: 20
   total_steps: 1000
-
-  lr_init: 3.0e-4
-  lr_target: 3.0e-4
-  opt_betas: [0.9, 0.95]
-  opt_eps: 1.0e-8
-  weight_decay: 1.0e-6
 
   checkpoint_interval: 10000
   eval_interval: 20
@@ -22,8 +10,28 @@ train:
   pipeline: "PromptPipeline"
   orchestrator: "PPOOrchestrator"
 
+model:
+  model_type: "AcceleratePPOModel"
+  model_path: "CarperAI/randomwalks"
+  tokenizer_path: "CarperAI/randomwalks"
+  num_layers_unfrozen: -1
+
+optimizer:
+  name: "adamw"
+  kwargs:
+    lr: 3.0e-4
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 1.0e-6
+
+scheduler:
+  name: "cosine_annealing"
+  kwargs:
+    T_max: 1000 # train.total_steps
+    eta_min: 3.0e-4
+
 method:
-  name: 'ppoconfig'
+  name: "ppoconfig"
   num_rollouts: 128
   chunk_size: 128
   ppo_epochs: 4

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,42 @@
-import accelerate
 import pytest
+import torch
 import transformers
 
+import accelerate
+import trlx.utils as utils
 import trlx.utils.modeling as modeling_utils
+
+# Test general utils
+
+
+@pytest.mark.parametrize(
+    "optimizer_name",
+    [o.value for o in utils.OptimizerNames],
+)
+def test_optimizer_class_getters(optimizer_name: str):
+    try:
+        _class = utils.get_optimizer_class(optimizer_name)
+    except Exception as e:
+        assert False, "Failed to get optimizer class with error: " + str(e)
+
+    # Hard-check for one of the optimizers
+    _class = utils.get_optimizer_class("adamw")
+    assert _class == torch.optim.AdamW
+
+
+@pytest.mark.parametrize(
+    "scheduler_name",
+    [o.value for o in utils.SchedulerNames],
+)
+def test_scheduler_class_getters(scheduler_name: str):
+    try:
+        _class = utils.get_scheduler_class(scheduler_name)
+    except Exception as e:
+        assert False, "Failed to get scheduler class with error: " + str(e)
+
+    # Hard-check for one of the schedulers
+    _class = utils.get_scheduler_class("cosine_annealing")
+    assert _class == torch.optim.lr_scheduler.CosineAnnealingLR
 
 
 # Test modeling utils

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -26,20 +26,64 @@ class ModelConfig:
     """
     Config for a model.
 
-    :param model_path: Path to the model (local or on huggingface hub)
-    :type model_path: str
-
-    :param tokenizer_path: Path to the tokenizer (local or on huggingface hub)
-    :type tokenizer_path: str
-
     :param model_type: One of the registered RL models present in trlx.model
     :type model_type: str
+
+    :param model_path: Path or name of the model (local or on huggingface hub)
+    :type model_path: str
+
+    :param tokenizer_path: Path or name of the tokenizer (local or on huggingface hub)
+    :type tokenizer_path: str
+
+    :param num_layers_unfrozen: Number of layers to unfreeze for fine-tuning.
+        -1 means all layers are unfrozen.
+    :type num_layers_unfrozen: int
     """
 
+    model_type: str
     model_path: str
     tokenizer_path: str
-    model_type: str
     num_layers_unfrozen: int = -1
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]):
+        return cls(**config)
+
+
+@dataclass
+class OptimizerConfig:
+    """
+    Config for an optimizer.
+
+    :param name: Name of the optimizer
+    :type name: str
+
+    :param kwargs: Keyword arguments for the optimizer (e.g. lr, betas, eps, weight_decay)
+    :type kwargs: Dict[str, Any]
+    """
+
+    name: str
+    kwargs: Dict[str, Any] = None
+
+    @classmethod
+    def from_dict(cls, config: Dict[str, Any]):
+        return cls(**config)
+
+
+@dataclass
+class SchedulerConfig:
+    """
+    Config for a learning rate scheduler.
+
+    :param name: Name of the scheduler
+    :type name: str
+
+    :param kwargs: Keyword arguments for the scheduler instance (e.g. warmup_steps, T_max)
+    :type kwargs: Dict[str, Any]
+    """
+
+    name: str
+    kwargs: Dict[str, Any] = None
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):
@@ -63,21 +107,6 @@ class TrainConfig:
     :param batch_size: Batch size for training
     :type batch_size: int
 
-    :param lr_init: Initial learning rate value
-    :type lr_init: float
-
-    :param lr_target: Target learning rate after decay
-    :type lr_target: float
-
-    :param opt_betas: Beta parameters for Adam optimizer
-    :type opt_betas: Tuple[float]
-
-    :param opt_eps: Epsilon for optimizer
-    :type opt_eps: float
-
-    :param weight_decay: Weight decay for optimizer
-    :type weight_decay: float
-
     :param checkpoint_interval: Save model every checkpoint_interval steps
     :type checkpoint_interval: int
 
@@ -90,17 +119,20 @@ class TrainConfig:
     :param orchestrator: Orchestrator to use for training. One of the registered orchestrators present in trlx.orchestrator
     :type orchestrator: str
 
-    :param checkpoint_dir: Directory to save checkpoints
-    :type checkpoint_dir: str
-
     :param project_name: Project name for wandb
     :type project_name: str
 
     :param entity_name: Entity name for wandb
     :type entity_name: str
 
+    :param checkpoint_dir: Directory to save checkpoints
+    :type checkpoint_dir: str
+
     :param rollout_logging_dir: Directory to store generated rollouts for use in Algorithm Distillation. Only used by AcceleratePPOModel.
     :type rollout_logging_dir: Optional[str]
+
+    :param seed: Random seed
+    :type seed: int
     """
 
     total_steps: int
@@ -108,24 +140,19 @@ class TrainConfig:
     epochs: int
     batch_size: int
 
-    lr_init: float
-    lr_target: float
-    opt_betas: Tuple[float]
-    opt_eps: float
-    weight_decay: float
-
     checkpoint_interval: int
     eval_interval: int
 
     pipeline: str  # One of the pipelines in framework.pipeline
     orchestrator: str  # One of the orchestrators
 
-    checkpoint_dir: str = "ckpts"
     project_name: str = "trlx"
     entity_name: Optional[str] = None
-    seed: int = 1000
 
+    checkpoint_dir: str = "ckpts"
     rollout_logging_dir: Optional[str] = None
+
+    seed: int = 1000
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):
@@ -138,9 +165,11 @@ class TRLConfig:
     Top level config for trlX. Loads configs and can be converted to dictionary.
     """
 
-    model: ModelConfig
-    train: TrainConfig
     method: MethodConfig
+    model: ModelConfig
+    optimizer: OptimizerConfig
+    scheduler: SchedulerConfig
+    train: TrainConfig
 
     @classmethod
     def load_yaml(cls, yml_fp: str):
@@ -152,37 +181,37 @@ class TRLConfig:
         """
         with open(yml_fp, mode="r") as file:
             config = yaml.safe_load(file)
-        return cls(
-            ModelConfig.from_dict(config["model"]),
-            TrainConfig.from_dict(config["train"]),
-            get_method(config["method"]["name"]).from_dict(config["method"]),
-        )
+        return cls.from_dict(config)
 
     def to_dict(self):
         """
         Convert TRLConfig to dictionary.
         """
         data = {
-            "model": self.model.__dict__,
-            "train": self.train.__dict__,
             "method": self.method.__dict__,
+            "model": self.model.__dict__,
+            "optimizer": self.optimizer.__dict__,
+            "scheduler": self.scheduler.__dict__,
+            "train": self.train.__dict__,
         }
 
         return data
 
     @classmethod
-    def from_dict(cls, config_dict: dict):
+    def from_dict(cls, config: Dict):
         """
         Convert dictionary to TRLConfig.
         """
         return cls(
-            ModelConfig.from_dict(config_dict["model"]),
-            TrainConfig.from_dict(config_dict["train"]),
-            get_method(config_dict["method"]["name"]).from_dict(config_dict["method"]),
+            method=get_method(config["method"]["name"]).from_dict(config["method"]),
+            model=ModelConfig.from_dict(config["model"]),
+            optimizer=OptimizerConfig.from_dict(config["optimizer"]),
+            scheduler=SchedulerConfig.from_dict(config["scheduler"]),
+            train=TrainConfig.from_dict(config["train"]),
         )
 
     @classmethod
-    def update(cls, baseconfig, config):
+    def update(cls, baseconfig: Dict, config: Dict):
         updates = set()
         merged = merge(baseconfig, config, updates)
 
@@ -193,3 +222,9 @@ class TRLConfig:
                 )
 
         return cls.from_dict(merged)
+
+    def __str__(self):
+        """Returns a human-readable string representation of the config."""
+        import json
+
+        return json.dumps(self.to_dict(), indent=4)

--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -1,20 +1,17 @@
 import importlib
-import sys
+import json
 import os
+import sys
 from abc import abstractmethod
 from time import time
 from typing import Any, Dict, Iterable, Sequence, Tuple, Union
 
-import json
 import torch
 import torch.nn.functional as F
-from accelerate import Accelerator  # type: ignore
 from transformers import AutoTokenizer
 
 import wandb
-from trlx.data.configs import TRLConfig
-from trlx.model import BaseRLModel, register_model
-from trlx.utils.modeling import freeze_bottom_causal_layers
+from accelerate import Accelerator  # type: ignore
 
 if importlib.util.find_spec("rich") is not None:
     from tqdm.rich import tqdm
@@ -24,7 +21,17 @@ else:
 import ray
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
-from trlx.utils import filter_non_scalars, get_distributed_config, get_git_tag
+
+from trlx.data.configs import TRLConfig
+from trlx.model import BaseRLModel, register_model
+from trlx.utils import (
+    filter_non_scalars,
+    get_optimizer_class,
+    get_scheduler_class,
+    get_distributed_config,
+    get_git_tag,
+)
+from trlx.utils.modeling import freeze_bottom_causal_layers
 
 
 @register_model
@@ -82,18 +89,14 @@ class AccelerateRLModel(BaseRLModel):
                 },
             )
 
-        self.opt = torch.optim.AdamW(
+        self.opt = get_optimizer_class(config.optimizer.name)(
             self.model.parameters(),
-            lr=self.config.train.lr_init,
-            betas=self.config.train.opt_betas,
-            eps=self.config.train.opt_eps,
-            weight_decay=self.config.train.weight_decay,
+            **config.optimizer.kwargs,
         )
 
-        self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        self.scheduler = get_scheduler_class(config.scheduler.name)(
             self.opt,
-            self.config.train.total_steps,
-            eta_min=self.config.train.lr_target,
+            **config.scheduler.kwargs,
         )
 
     def tokenize(self, text: Union[Sequence[str], Sequence[torch.LongTensor]]):

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -1,6 +1,7 @@
 import os
 import random
 import time
+from enum import Enum
 from functools import reduce
 from typing import Any, Iterable, List, Dict
 from dataclasses import is_dataclass
@@ -84,6 +85,50 @@ def get_distributed_config(accelerator: Accelerator):
         )
 
     return dist_config
+
+
+class OptimizerNames(Enum):
+    """Supported optimizer names"""
+
+    ADAM: str = "adam"
+    ADAMW: str = "adamw"
+    SGD: str = "sgd"
+
+
+def get_optimizer_class(name: str):
+    """
+    Returns the optimizer class with the given name
+    """
+    if name == OptimizerNames.ADAM.value:
+        return torch.optim.Adam
+    if name == OptimizerNames.ADAMW.value:
+        return torch.optim.AdamW
+    if name == OptimizerNames.SGD.value:
+        return torch.optim.SGD
+    supported_optimizers = [o.value for o in OptimizerNames]
+    raise ValueError(
+        f"`{name}` is not a supported optimizer. "
+        f"Supported optimizers are: {supported_optimizers}"
+    )
+
+
+class SchedulerNames(Enum):
+    """Supported scheduler names"""
+
+    COSINE_ANNEALING: str = "cosine_annealing"
+
+
+def get_scheduler_class(name: str):
+    """
+    Returns the scheduler class with the given name
+    """
+    if name == SchedulerNames.COSINE_ANNEALING.value:
+        return torch.optim.lr_scheduler.CosineAnnealingLR
+    supported_schedulers = [s.value for s in SchedulerNames]
+    raise ValueError(
+        f"`{name}` is not a supported scheduler. "
+        f"Supported schedulers are: {supported_schedulers}"
+    )
 
 
 # Stats


### PR DESCRIPTION
This PR adds the following configuration updates:

- Adds an `OptimizerConfig` dedicated to customizing optimizer specifications.
    - Previously users were hard constrained to `torch.optim.AdamW`.
    - This should make it easier to add other optimizers like 8-bit optimizers
      introduced in PR #133

- Adds a `SchedulerConfig` for customizing the learning rate scheduler.
    - Previously users were hard constrained to `torch.optim.lr_scheduler.CosineAnnealingLR`; this opens possibilities for other schedulers like `torch.optim.lr_scheduler.OneCycleLR` if desired from the community 

Notes:

- This PR formats the config YAML files throughout the repository to be more
  consistent.

`wandb` reports: [PPO/ILQL Sentiments](https://wandb.ai/jon-tow/trlx/reports/trlx-Add-OptimizerConfig-and-SchedulerConfig-135--VmlldzozMTQ1NTQw?accessToken=b3quf5f60zz3quxch85w2p5avobeop5hb73sgydoadfsu89get5y0lykzeqjmv4p)


@ reviewer: I found these updates useful to me; if this feature is not desired or designed appropriately feel free to suggest edits or close.
