### PR TITLE
add: load function for AccelerateRLModel

### DIFF
--- a/trlx/model/__init__.py
+++ b/trlx/model/__init__.py
@@ -96,41 +96,14 @@ class BaseRLModel:
         pass
 
     @abstractmethod
-    def get_components(self) -> Dict[str, Any]:
-        """
-        Get pytorch components (mainly for saving/loading)
-        """
+    def save(self, directory=None):
+        """Create checkpoint of model"""
         pass
 
-    def save(self, fp: str, title: str = "OUT"):
-        """
-        Try to save all components to specified path under a folder with given title
-        """
-        path = os.path.join(fp, title)
-        safe_mkdir(path)
-
-        components = self.get_components()
-        for name in components:
-            try:
-                torch.save(components[name], os.path.join(path, name) + ".pt")
-            except:
-                print(f"Failed to save component: {name}, continuing.")
-
-    def load(self, fp: str, title: str = "OUT"):
-        """
-        Try to load all components from specified path under a folder with given title
-        """
-
-        path = os.path.join(fp, title)
-
-        components = self.get_components()
-        for name in components:
-            try:
-                components[name] = torch.load(
-                    os.path.join(path, name) + ".pt", map_location="cpu"
-                )
-            except:
-                print(f"Failed to load component: {name}, continuing.")
+    @abstractmethod
+    def load(self, directory=None):
+        """Load Checkpoints for model"""
+        pass
 
     def intervals(self, steps: int) -> Dict[str, bool]:
         """

--- a/trlx/model/__init__.py
+++ b/trlx/model/__init__.py
@@ -97,12 +97,12 @@ class BaseRLModel:
 
     @abstractmethod
     def save(self, directory=None):
-        """Create checkpoint of model"""
+        """Creates a checkpoint of training states"""
         pass
 
     @abstractmethod
     def load(self, directory=None):
-        """Load Checkpoints for model"""
+        """Loads a checkpoint created from `save`"""
         pass
 
     def intervals(self, steps: int) -> Dict[str, bool]:

--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -128,20 +128,12 @@ class AccelerateRLModel(BaseRLModel):
                 input_ids=input_ids, attention_mask=attention_mask, **kwargs
             )
 
-    def get_components(self) -> Dict[str, Any]:
-        components = (
-            {"model": self.model, "opt": self.opt, "scheduler": self.scheduler}
-            if self.train_mode
-            else {"model": self.model}
-        )
-        return components
-
     def save(self, directory=None):
         """Creates checkpoint of optimizer, scheduler and a model"""
         self.accelerator.save_state(directory or self.config.train.checkpoint_dir)
 
     def load(self, directory=None):
-        """load checkpoint of optimizer, scheduler and a model"""
+        """Load checkpoint of optimizer, scheduler and a model"""
         self.accelerator.load_state(directory or self.config.train.checkpoint_dir)
 
     def add_eval_pipeline(self, eval_pipeline):

--- a/trlx/model/accelerate_base_model.py
+++ b/trlx/model/accelerate_base_model.py
@@ -140,6 +140,10 @@ class AccelerateRLModel(BaseRLModel):
         """Creates checkpoint of optimizer, scheduler and a model"""
         self.accelerator.save_state(directory or self.config.train.checkpoint_dir)
 
+    def load(self, directory=None):
+        """load checkpoint of optimizer, scheduler and a model"""
+        self.accelerator.load_state(directory or self.config.train.checkpoint_dir)
+
     def add_eval_pipeline(self, eval_pipeline):
         """Adds pipeline from with validation prompts"""
         self.eval_pipeline = eval_pipeline


### PR DESCRIPTION
# save and load are being done in different ways.

After performing the example, the model that was save at `ckpts`
it call https://github.com/CarperAI/trlx/blob/1a3461d592a567409e11e3c47b5b355bf219449f/trlx/model/accelerate_base_model.py#L139
when I use `ckpts` weight it call https://github.com/CarperAI/trlx/blob/1a3461d592a567409e11e3c47b5b355bf219449f/trlx/model/__init__.py#L119

