### PR TITLE
Remove incorrect default config settings

### DIFF
--- a/configs/ppo_config.yml
+++ b/configs/ppo_config.yml
@@ -9,7 +9,6 @@ train:
 
   pipeline: "PromptPipeline"
   orchestrator: "PPOOrchestrator"
-  entity_name: "jon-tow"
 
 model:
   model_type: "AcceleratePPOModel"
@@ -18,7 +17,7 @@ model:
   num_layers_unfrozen: 2
 
 optimizer:
-  name: "adam"
+  name: "adamw"
   kwargs:
     lr: 1.0e-4
     betas: [0.9, 0.95]

--- a/configs/ppo_gptj.yml
+++ b/configs/ppo_gptj.yml
@@ -9,7 +9,6 @@ train:
 
   pipeline: "PromptPipeline"
   orchestrator: "PPOOrchestrator"
-  entity_name: "jon-tow"
 
 model:
   model_type: "AcceleratePPOModel"


### PR DESCRIPTION
This PR removes my wandb login info and reverts the default ppo config optimizer to "adamw". I'm an idiot. 

Discovered by @reciprocated in #131 and prioritizing here.