### PR TITLE
Freeze hydra model branches 

### DIFF
--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -31,6 +31,11 @@ class TestHydraHead(unittest.TestCase):
             diff = torch.sum(unfrozen_logits - frozen_logits).item()
             self.assertEqual(diff, 0)
 
+    def test_frozen_head(self):
+        # Ensure that all parameters of the `hydra_model.frozen_head` are actually frozen
+        for parameter in TestHydraHead.hydra_model.frozen_head.parameters():
+            self.assertTrue(parameter.requires_grad == False)
+
     def test_forward(self):
         with torch.no_grad():
             unfrozen_outputs = TestHydraHead.hydra_model(**TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True)

--- a/trlx/model/nn/ppo_models.py
+++ b/trlx/model/nn/ppo_models.py
@@ -431,11 +431,8 @@ class GPTModelBranch(transformers.PreTrainedModel):
         self.gradient_checkpointing = False
 
         # Turning off grad saves memory
-        for block in self.transformer_blocks:
-            for parameter in block.parameters():
-                parameter.requires_grad = False
-        for parameter in lm_head.parameters():
-            parameter.requires_grad = False
+        for parameter in self.parameters():
+            parameter.requires_grad_(False)
 
     def forward(
         self,
@@ -649,11 +646,8 @@ class OPTModelBranch(transformers.PreTrainedModel):
         self.gradient_checkpointing = False
 
         # Turning off grad saves memory
-        for block in self.transformer_blocks:
-            for parameter in block.parameters():
-                parameter.requires_grad = False
-        for parameter in lm_head.parameters():
-            parameter.requires_grad = False
+        for parameter in self.parameters():
+            parameter.requires_grad_(False)
 
     def forward(
         self,
@@ -831,11 +825,8 @@ class BloomModelBranch(transformers.PreTrainedModel):
         self.gradient_checkpointing = False
 
         # Turning off grad saves memory
-        for block in self.transformer_blocks:
-            for parameter in block.parameters():
-                parameter.requires_grad = False
-        for parameter in lm_head.parameters():
-            parameter.requires_grad = False
+        for parameter in self.parameters():
+            parameter.requires_grad_(False)
 
     def forward(
         self,


### PR DESCRIPTION
This PR updates the `ModelBranch` classes used in the PPO hydra architectures to freeze all parameters by default.
Currently, only the transformer blocks are frozen. Note that the `ModelBranch.lm_head`s are never frozen but the
`lm_head` they are `deepcopy`ed from are instead.

wandb report: [PPO](https://wandb.ai/jon-tow/trlx/reports/trlx-fix-frozen-branch-PR--VmlldzozMTY4Njc1)