### PR TITLE
Set device-specific seeding with global rank

### DIFF
--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -20,7 +20,7 @@ def set_seed(seed: int):
     """
     Sets seeds across package dependencies for reproducibility.
     """
-    seed += int(os.environ.get("LOCAL_RANK", 0))
+    seed += int(os.environ.get("RANK", 0))
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)


### PR DESCRIPTION
I overlooked this in the review of #141. With `LOCAL_RANK`, each device in a single node gets a unique seed but we probably want unique seeds across nodes as well for true device-specific seeding.