### PR TITLE
Release 0.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,25 @@
 [metadata]
 name = trlx
 author = Alex Havrilla
-version = 0.3.0
+version = 0.3.1
 url = https://github.com/CarperAI/trlx
-description = A repo for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF)
+download_url = https://github.com/CarperAI/trlx/tags
+description = A framework for distributed training of language models with Reinforcement Learning via Human Feedback (RLHF)
 long_description = file: README.md
 long_description_content_type = text/markdown
+keywords =
+    deep learning
+    reinforcement learning
+    language modeling
 license = MIT
+classifier =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Intended Audience :: Education
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Artificial Intelligence
 
 [options]
 packages = find:
@@ -35,5 +48,70 @@ dev =
 
 [options.packages.find]
 exclude =
+    configs*
     docs*
+    examples*
     tests*
+
+# Manual instructions for publishing a new version of the package on PyPI:
+#
+#   REMINDER: Use semantic versioning, https://semver.org/
+#
+# 0. Make sure you have an account on both https://pypi.org/ and https://test.pypi.org/
+#   and the latest version of `twine` installed:
+#
+#   ```sh
+#   pip install --upgrade twine
+#   ```
+#
+# 1. Create a release branch from `main` in your local fork:
+#
+#   ```sh
+#   git checkout main
+#   git pull upstream main
+#   git checkout -b release-{major}.{minor}.{patch}
+#   ```
+#
+# 2. Update the version number in `setup.cfg`, commit, and push the changes to the release branch:
+#
+#   ```sh
+#   git add setup.cfg
+#   git commit -m "Release {major}.{minor}.{patch}"
+#   git push origin release-{major}.{minor}.{patch}
+#   ```
+#
+# 4. Create a pull request from the release branch to `main`: https://github.com/CarperAI/trlx/pull/new/release
+#
+# 5. Build the wheel and source distribution:
+#
+#   ```sh
+#   python setup.py sdist bdist_wheel
+#   ```
+#
+# 6. Upload test version to https://test.pypi.org/:
+#
+#   ```sh
+#   twine upload dist/* -r pypitest --repository-url=https://test.pypi.org/legacy/
+#   ```
+#
+#   and ensure proper packaging/installation from `test.pypi.org`:
+#
+#   ```sh
+#   pip install -i https://test.pypi.org/simple/ trlx
+#   python -c "from trlx import *"
+#   ```
+#
+# 7. If everything goes well, push the release to PyPI:
+#
+#   ```sh
+#   twine upload dist/* -r pypi
+#   ```
+#
+# 8. Create a new release on GitHub
+#   - Merge the release Pull Request into `main`
+#   - Create a new release on GitHub: https://github.com/CarperAI/trlx/releases/new
+#       - Tag the release with the version number, e.g. `v0.1.0`
+#       - Use the `Generate release notes` button to generate the release notes
+#       - Click `Publish release`
+#
+# Reference: https://github.com/huggingface/datasets/blob/main/setup.py


### PR DESCRIPTION
Bump patch version for the first release on PyPI.

**Note**: Installing from TestPyPI currently does not work because some dependencies are not available in the TestPyPI index, e.g. there does not exist a `deepspeed>=0.7.3` in the index.

Do not merge this PR until the package is released on PyPI.