### PR TITLE
Fix instantiating base transformer from a custom config

### DIFF
--- a/trlx/trainer/nn/ilql_models.py
+++ b/trlx/trainer/nn/ilql_models.py
@@ -197,14 +197,14 @@ class CausalLMWithValueHeads(nn.Module):
                 _hfconfig = transformers.deepspeed.HfDeepSpeedConfig(  # noqa: F841
                     config_path
                 )
+
         if isinstance(config, str):
             self.config = transformers.AutoConfig.from_pretrained(config)
+            self.base_model = transformers.AutoModelForCausalLM.from_pretrained(config)
         else:
             self.config = config
+            self.base_model = transformers.AutoModelForCausalLM.from_config(config)
 
-        self.base_model = transformers.AutoModelForCausalLM.from_pretrained(
-            self.config.name_or_path,
-        )
         self.base_model.transformer = hf_get_causal_base_model(self.base_model)
         self.base_model.lm_head = hf_get_lm_head(self.base_model)
         freeze_bottom_causal_layers(self.base_model, num_layers_unfrozen)

--- a/trlx/trainer/nn/ppo_models.py
+++ b/trlx/trainer/nn/ppo_models.py
@@ -232,11 +232,11 @@ class CausalLMWithValueHead(nn.Module):
         super().__init__()
         if isinstance(config, str):
             self.config = transformers.AutoConfig.from_pretrained(config)
+            self.base_model = transformers.AutoModelForCausalLM.from_pretrained(config)
         else:
             self.config = config
-        self.base_model = transformers.AutoModelForCausalLM.from_pretrained(
-            self.config.name_or_path
-        )
+            self.base_model = transformers.AutoModelForCausalLM.from_config(config)
+
         self.base_model.transformer = hf_get_causal_base_model(self.base_model)
         self.base_model.lm_head = hf_get_lm_head(self.base_model)
         self.v_head = make_head(hf_get_hidden_size(self.config), 1)
@@ -304,13 +304,14 @@ class CausalLMHydraWithValueHead(nn.Module):
         num_layers_unfrozen: int = -1,
     ):
         super().__init__()
+
         if isinstance(config, str):
             self.config = transformers.AutoConfig.from_pretrained(config)
+            self.base_model = transformers.AutoModelForCausalLM.from_pretrained(config)
         else:
             self.config = config
-        self.base_model = transformers.AutoModelForCausalLM.from_pretrained(
-            self.config.name_or_path
-        )
+            self.base_model = transformers.AutoModelForCausalLM.from_config(config)
+
         self.base_model.transformer = hf_get_causal_base_model(self.base_model)
         self.base_model.lm_head = hf_get_lm_head(self.base_model)
         self.v_head = make_head(hf_get_hidden_size(self.config), 1)


### PR DESCRIPTION
This pr enables usage of not pretrained transformers as base models, in particular it fixes [examples/randomwalks/ilql_randomwalks.py](https://github.com/CarperAI/trlx/blob/main/examples/randomwalks/ilql_randomwalks.py) which was broken previously.

[PPO/ILQL randomwalks runs with/without pretrain](https://wandb.ai/sorry/public/reports/Fix-instantiating-base-transformer-from-a-custom-config-149---VmlldzozMjA3OTAy)