### PR TITLE
Linear LR scheduler

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
+import accelerate
 import pytest
 import torch
 import transformers
 
-import accelerate
 import trlx.utils as utils
 import trlx.utils.modeling as modeling_utils
 
@@ -11,7 +11,7 @@ import trlx.utils.modeling as modeling_utils
 
 @pytest.mark.parametrize(
     "optimizer_name",
-    [o.value for o in utils.OptimizerNames],
+    [o.value for o in utils.OptimizerName],
 )
 def test_optimizer_class_getters(optimizer_name: str):
     try:
@@ -26,7 +26,7 @@ def test_optimizer_class_getters(optimizer_name: str):
 
 @pytest.mark.parametrize(
     "scheduler_name",
-    [o.value for o in utils.SchedulerNames],
+    [o.value for o in utils.SchedulerName],
 )
 def test_scheduler_class_getters(scheduler_name: str):
     try:

--- a/trlx/trainer/__init__.py
+++ b/trlx/trainer/__init__.py
@@ -8,7 +8,6 @@ import torch
 from trlx.data import RLElement
 from trlx.data.configs import TRLConfig
 from trlx.pipeline import BaseRolloutStore
-from trlx.utils import safe_mkdir
 
 # specifies a dictionary of architectures
 _TRAINERS: Dict[str, Any] = {}  # registry

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -26,6 +26,7 @@ def set_seed(seed: int):
 
 # Training utils
 
+
 def get_distributed_config(accelerator: Accelerator):
     """
     Return accelerator distributed config

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -1,19 +1,16 @@
 import os
 import random
-import time
-from enum import Enum
-from functools import reduce
-from typing import Any, Iterable, List, Dict
-from dataclasses import is_dataclass
 import subprocess
+import time
+from dataclasses import is_dataclass
+from enum import Enum
+from typing import Dict, Iterable
 
 import numpy as np
 import torch
-from torch.optim.lr_scheduler import ChainedScheduler, LinearLR
-from torchtyping import TensorType
-
-import accelerate
 from accelerate import Accelerator
+from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR
+from torchtyping import TensorType
 
 
 def set_seed(seed: int):
@@ -27,40 +24,7 @@ def set_seed(seed: int):
     torch.cuda.manual_seed(seed)
 
 
-def flatten(L: Iterable[Iterable[Any]]) -> Iterable[Any]:
-    """
-    Flatten a list of lists into a single list (i.e. [[1, 2], [3, 4]] -> [1,2,3,4])
-    """
-    return list(reduce(lambda acc, x: acc + x, L, []))
-
-
-def chunk(L: Iterable[Any], chunk_size: int) -> List[Iterable[Any]]:
-    """
-    Chunk iterable into list of iterables of given chunk size
-    """
-    return [L[i : i + chunk_size] for i in range(0, len(L), chunk_size)]
-
-
 # Training utils
-
-
-def rampup_decay(ramp_steps, decay_steps, decay_target, opt):
-    return ChainedScheduler(
-        [
-            LinearLR(opt, decay_target, 1, total_iters=ramp_steps),
-            LinearLR(opt, 1, decay_target, total_iters=decay_steps),
-        ]
-    )
-
-
-def safe_mkdir(path: str):
-    """
-    Make directory if it doesn't exist, otherwise do nothing
-    """
-    if os.path.isdir(path):
-        return
-    os.mkdir(path)
-
 
 def get_distributed_config(accelerator: Accelerator):
     """
@@ -88,44 +52,47 @@ def get_distributed_config(accelerator: Accelerator):
     return dist_config
 
 
-class OptimizerNames(Enum):
+class OptimizerName(str, Enum):
     """Supported optimizer names"""
 
-    ADAM: str = "adam"
-    ADAMW: str = "adamw"
-    SGD: str = "sgd"
+    ADAM = "adam"
+    ADAMW = "adamw"
+    SGD = "sgd"
 
 
-def get_optimizer_class(name: str):
+def get_optimizer_class(name: OptimizerName):
     """
     Returns the optimizer class with the given name
     """
-    if name == OptimizerNames.ADAM.value:
+    if name == OptimizerName.ADAM:
         return torch.optim.Adam
-    if name == OptimizerNames.ADAMW.value:
+    if name == OptimizerName.ADAMW:
         return torch.optim.AdamW
-    if name == OptimizerNames.SGD.value:
+    if name == OptimizerName.SGD:
         return torch.optim.SGD
-    supported_optimizers = [o.value for o in OptimizerNames]
+    supported_optimizers = [o.value for o in OptimizerName]
     raise ValueError(
         f"`{name}` is not a supported optimizer. "
         f"Supported optimizers are: {supported_optimizers}"
     )
 
 
-class SchedulerNames(Enum):
+class SchedulerName(str, Enum):
     """Supported scheduler names"""
 
-    COSINE_ANNEALING: str = "cosine_annealing"
+    COSINE_ANNEALING = "cosine_annealing"
+    LINEAR = "linear"
 
 
-def get_scheduler_class(name: str):
+def get_scheduler_class(name: SchedulerName):
     """
     Returns the scheduler class with the given name
     """
-    if name == SchedulerNames.COSINE_ANNEALING.value:
-        return torch.optim.lr_scheduler.CosineAnnealingLR
-    supported_schedulers = [s.value for s in SchedulerNames]
+    if name == SchedulerName.COSINE_ANNEALING:
+        return CosineAnnealingLR
+    if name == SchedulerName.LINEAR:
+        return LinearLR
+    supported_schedulers = [s.value for s in SchedulerName]
     raise ValueError(
         f"`{name}` is not a supported scheduler. "
         f"Supported schedulers are: {supported_schedulers}"


### PR DESCRIPTION
In this PR:

- Linear LR scheduler is added. It was used in InstructGPT. From the [paper](https://arxiv.org/abs/2203.02155):

<img width="890" alt="image" src="https://user-images.githubusercontent.com/25286019/209449756-293e5b00-9ea4-40af-a27a-7716139abeb1.png">


-  Tested with config:

```yaml
scheduler:
  name: "linear"
  kwargs:
    start_factor: 0.1
    end_factor: 1.0
    total_iters: 64
```

<img width="535" alt="image" src="https://user-images.githubusercontent.com/25286019/209449687-16f9534a-a95a-4ef2-8db3-7519d99f6a62.png">


- Some unused code is removed
