### PR TITLE
Update `pre-commit` version and add `isort`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-# This should be the _latest_ version of python supported by us
-default_language_version:
-  python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,4 +11,9 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
-        files: ^(trlx|examples|unittests|setup.py)/
+        files: ^(trlx|examples|tests|setup.py)/
+-   repo: https://github.com/pycqa/isort
+    rev: 5.11.2
+    hooks:
+    -   id: isort
+        name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../..'))
 
 

--- a/examples/architext.py
+++ b/examples/architext.py
@@ -1,6 +1,7 @@
 # Toy example of optimizing textual interior designs to output the least number of rooms
 # Also see https://architext.design/
 import yaml
+
 import trlx
 from trlx.data.configs import TRLConfig
 

--- a/examples/experiments/grounded_program_synthesis/train_trlx.py
+++ b/examples/experiments/grounded_program_synthesis/train_trlx.py
@@ -1,10 +1,11 @@
-import trlx
-from trlx.data.configs import TRLConfig
-from lang import Interpreter
 import json
 import logging
-import yaml
 
+import yaml
+from lang import Interpreter
+
+import trlx
+from trlx.data.configs import TRLConfig
 
 logger = logging.getLogger(__name__)
 

--- a/examples/ilql_sentiments.py
+++ b/examples/ilql_sentiments.py
@@ -1,10 +1,11 @@
-from datasets import load_dataset
+import os
+from typing import Dict, List
+
+import yaml
 from transformers import pipeline
 
 import trlx
-import yaml
-from typing import List, Dict
-import os
+from datasets import load_dataset
 from trlx.data.configs import TRLConfig
 
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -1,14 +1,15 @@
 # Generates positive movie reviews by tuning a pretrained model on IMDB dataset
 # with a sentiment reward function
 
-from datasets import load_dataset
-from transformers import pipeline
 import os
+from typing import List
+
+import torch
 import yaml
+from transformers import pipeline
 
 import trlx
-import torch
-from typing import List
+from datasets import load_dataset
 from trlx.data.configs import TRLConfig
 
 

--- a/examples/randomwalks/ilql_randomwalks.py
+++ b/examples/randomwalks/ilql_randomwalks.py
@@ -1,10 +1,11 @@
-from examples.randomwalks import generate_random_walks
-
 import os
-import trlx
-from trlx.data.configs import TRLConfig
+
 import yaml
 from transformers import GPT2Config
+
+import trlx
+from examples.randomwalks import generate_random_walks
+from trlx.data.configs import TRLConfig
 
 config_path = os.path.join(os.path.dirname(__file__), "configs/ilql_randomwalks.yml")
 default_config = yaml.safe_load(open(config_path))

--- a/examples/randomwalks/ppo_randomwalks.py
+++ b/examples/randomwalks/ppo_randomwalks.py
@@ -1,9 +1,10 @@
-from examples.randomwalks import generate_random_walks
+import os
 
 import yaml
+
 import trlx
+from examples.randomwalks import generate_random_walks
 from trlx.data.configs import TRLConfig
-import os
 
 config_path = os.path.join(os.path.dirname(__file__), "configs/ppo_randomwalks.yml")
 default_config = yaml.safe_load(open(config_path))

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -1,10 +1,9 @@
 # Optimize prompts by training on prompts-ratings pairings dataset
 # taken from https://github.com/JD-P/simulacra-aesthetic-captions
 
-import sqlite3
-
-from urllib.request import urlretrieve
 import os
+import sqlite3
+from urllib.request import urlretrieve
 
 import trlx
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.isort]
 multi_line_output = 3
+profile = "black"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,7 +1,7 @@
 import os
+from typing import List
 
 from trlx.data.configs import TRLConfig
-from typing import List
 
 
 def _get_config_dirs(dir: str, config_dir_name: str = "configs") -> List[str]:
@@ -26,13 +26,16 @@ def _get_yaml_filepaths(dir: str) -> List[str]:
 def test_repo_trl_configs():
     """Tests to ensure all default configs in the repository are valid."""
     config_dirs = ["configs", *_get_config_dirs("examples")]
-    config_files = sum(map(_get_yaml_filepaths, config_dirs), [])  # sum for flat-map behavior
+    config_files = sum(
+        map(_get_yaml_filepaths, config_dirs), []
+    )  # sum for flat-map behavior
     for file in config_files:
         assert os.path.isfile(file), f"Config file {file} does not exist."
         assert file.endswith(".yml"), f"Config file {file} is not a yaml file."
         try:
             config = TRLConfig.load_yaml(file)
-            assert config.train.entity_name is None, \
-                f"Unexpected entity name in config file `{file}`. Remove before pushing to repo."
+            assert (
+                config.train.entity_name is None
+            ), f"Unexpected entity name in config file `{file}`. Remove before pushing to repo."
         except Exception as e:
             assert False, f"Failed to load config file `{file}` with error `{e}`"

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -1,9 +1,11 @@
 import unittest
+
+import torch
+from transformers import AutoTokenizer
+
 from trlx.data.configs import TRLConfig
 from trlx.trainer.nn.ppo_models import CausalLMHydraWithValueHead
 from trlx.utils.modeling import RunningMoments
-from transformers import AutoTokenizer
-import torch
 
 
 # Note tests must start with "test_"
@@ -20,14 +22,26 @@ class TestHydraHead(unittest.TestCase):
         tokenizer.pad_token = tokenizer.eos_token
         tokenizer.padding_side = "left"
 
-        cls.dummy_inputs = tokenizer("Once upon a time there was a happy goose named Louis. He liked to eat bananas.", truncation=True, padding="max_length", max_length=4, return_tensors="pt")
+        cls.dummy_inputs = tokenizer(
+            "Once upon a time there was a happy goose named Louis. He liked to eat bananas.",
+            truncation=True,
+            padding="max_length",
+            max_length=4,
+            return_tensors="pt",
+        )
 
     def test_lm_heads(self):
         with torch.no_grad():
-            unfrozen_outputs = TestHydraHead.hydra_model(**TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True)
+            unfrozen_outputs = TestHydraHead.hydra_model(
+                **TestHydraHead.dummy_inputs,
+                return_dict=True,
+                output_hidden_states=True
+            )
             unfrozen_logits = unfrozen_outputs.logits
             last_hidden_states = unfrozen_outputs.hidden_states[-1].to(torch.float32)
-            frozen_logits = TestHydraHead.hydra_model.frozen_head.lm_head(last_hidden_states)
+            frozen_logits = TestHydraHead.hydra_model.frozen_head.lm_head(
+                last_hidden_states
+            )
             diff = torch.sum(unfrozen_logits - frozen_logits).item()
             self.assertEqual(diff, 0)
 
@@ -38,18 +52,29 @@ class TestHydraHead(unittest.TestCase):
 
     def test_forward(self):
         with torch.no_grad():
-            unfrozen_outputs = TestHydraHead.hydra_model(**TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True)
+            unfrozen_outputs = TestHydraHead.hydra_model(
+                **TestHydraHead.dummy_inputs,
+                return_dict=True,
+                output_hidden_states=True
+            )
             unfrozen_last_hidden_states = unfrozen_outputs.hidden_states[-1]
             unfrozen_logits = unfrozen_outputs.logits
 
-            frozen_outputs = TestHydraHead.hydra_model.forward_hydra(**TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True)
+            frozen_outputs = TestHydraHead.hydra_model.forward_hydra(
+                **TestHydraHead.dummy_inputs,
+                return_dict=True,
+                output_hidden_states=True
+            )
             frozen_last_hidden_states = frozen_outputs.hidden_states[-1]
             frozen_logits = frozen_outputs.logits
 
-            hs_diff = torch.sum(unfrozen_last_hidden_states - frozen_last_hidden_states).item()
+            hs_diff = torch.sum(
+                unfrozen_last_hidden_states - frozen_last_hidden_states
+            ).item()
             logits_diff = torch.sum(unfrozen_logits - frozen_logits).item()
             self.assertEqual(hs_diff, 0)
             self.assertEqual(logits_diff, 0)
+
 
 class TestStatistics(unittest.TestCase):
     @classmethod
@@ -61,10 +86,18 @@ class TestStatistics(unittest.TestCase):
         cls.a4 = torch.tensor([-10, -1, 0, 1, 10], dtype=float)
 
     def test_running_moments(self):
-        assert torch.isclose(self.m.update(self.a1)[1], self.a1.std(unbiased=True), atol=1e-6)
-        assert torch.isclose(self.m.update(self.a2)[1], self.a2.std(unbiased=True), atol=1e-6)
-        assert torch.isclose(self.m.update(self.a3)[1], self.a3.std(unbiased=True), atol=1e-6)
-        assert torch.isclose(self.m.update(self.a4)[1], self.a4.std(unbiased=True), atol=1e-6)
+        assert torch.isclose(
+            self.m.update(self.a1)[1], self.a1.std(unbiased=True), atol=1e-6
+        )
+        assert torch.isclose(
+            self.m.update(self.a2)[1], self.a2.std(unbiased=True), atol=1e-6
+        )
+        assert torch.isclose(
+            self.m.update(self.a3)[1], self.a3.std(unbiased=True), atol=1e-6
+        )
+        assert torch.isclose(
+            self.m.update(self.a4)[1], self.a4.std(unbiased=True), atol=1e-6
+        )
 
         a = torch.hstack((self.a1, self.a2, self.a3, self.a4))
         assert torch.isclose(self.m.mean, a.mean(), atol=1e-6)

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, Set
+from typing import Any, Dict, Optional, Set
 
 import yaml
 
 from trlx.data.method_configs import MethodConfig, get_method
-import os
 
 
 def merge(base: Dict, update: Dict, updated: Set) -> Dict:

--- a/trlx/orchestrator/__init__.py
+++ b/trlx/orchestrator/__init__.py
@@ -2,8 +2,8 @@ import sys
 from abc import abstractmethod
 from typing import Dict
 
-from trlx.trainer import BaseRLTrainer
 from trlx.pipeline import BasePipeline
+from trlx.trainer import BaseRLTrainer
 
 # specifies a dictionary of architectures
 _ORCH: Dict[str, any] = {}  # registry

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -1,16 +1,16 @@
+from time import time
 from typing import Callable
 
+import ray
 import torch
+
 from trlx.data.accelerate_base_datatypes import PromptBatch
 from trlx.data.ppo_types import PPORLElement
-from trlx.trainer import BaseRLTrainer
 from trlx.orchestrator import Orchestrator, register_orchestrator
 from trlx.pipeline import BasePipeline
+from trlx.trainer import BaseRLTrainer
 from trlx.utils import Clock
-from trlx.utils.modeling import logprobs_from_logits, RunningMoments
-
-from time import time
-import ray
+from trlx.utils.modeling import RunningMoments, logprobs_from_logits
 
 
 @register_orchestrator

--- a/trlx/pipeline/__init__.py
+++ b/trlx/pipeline/__init__.py
@@ -3,7 +3,6 @@ import sys
 from abc import abstractmethod, abstractstaticmethod
 from typing import Any, Callable, Dict, Iterable
 
-from datasets import load_from_disk
 from torch.utils.data import DataLoader, Dataset
 
 from trlx.data import GeneralElement, RLElement

--- a/trlx/pipeline/ppo_pipeline.py
+++ b/trlx/pipeline/ppo_pipeline.py
@@ -1,5 +1,6 @@
-import os, json, time
-
+import json
+import os
+import time
 from typing import Iterable, Optional
 
 from torch.nn.utils.rnn import pad_sequence

--- a/trlx/ray_tune/train_funcs.py
+++ b/trlx/ray_tune/train_funcs.py
@@ -1,9 +1,8 @@
 # Find the optimal hyperparameters to generates positive movie
 # reviews by tuning a pretrained on IMDB model with a sentiment reward function.
 
-from datasets import load_dataset
-
 import trlx
+from datasets import load_dataset
 from trlx.data.configs import TRLConfig
 
 

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -1,10 +1,11 @@
 """Utility function to log the results of a Ray Tune experiment to W&B."""
 
-import os
 import json
-import pandas as pd
-from pathlib import Path
 import math
+import os
+from pathlib import Path
+
+import pandas as pd
 
 import wandb
 

--- a/trlx/sweep.py
+++ b/trlx/sweep.py
@@ -1,21 +1,15 @@
 # python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentiments.py
-import wandb
 import argparse
+import importlib
 from pathlib import Path
 
 import ray
-from ray.air import session
-from ray import tune
-import importlib
 import yaml
-
-import trlx
-from trlx.ray_tune import get_param_space
-from trlx.ray_tune import get_tune_config
-from trlx.ray_tune.wandb import log_trials, create_report
-
-from ray.tune.logger import JsonLoggerCallback
+from ray import tune
 from ray.tune.logger import CSVLoggerCallback
+
+from trlx.ray_tune import get_param_space, get_tune_config
+from trlx.ray_tune.wandb import create_report, log_trials
 
 
 def tune_function(

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -8,10 +8,10 @@ from typing import Dict, Sequence, Tuple, Union
 
 import torch
 import torch.nn.functional as F
+from accelerate import Accelerator  # type: ignore
 from transformers import AutoTokenizer
 
 import wandb
-from accelerate import Accelerator  # type: ignore
 
 if importlib.util.find_spec("rich") is not None:
     from tqdm.rich import tqdm
@@ -26,10 +26,10 @@ from trlx.data.configs import TRLConfig
 from trlx.trainer import BaseRLTrainer, register_trainer
 from trlx.utils import (
     filter_non_scalars,
-    get_optimizer_class,
-    get_scheduler_class,
     get_distributed_config,
     get_git_tag,
+    get_optimizer_class,
+    get_scheduler_class,
 )
 from trlx.utils.modeling import freeze_bottom_causal_layers
 

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -3,12 +3,11 @@ from typing import Iterable, Sequence, Union, cast
 import torch
 import torch.nn.functional as F
 
-
+from trlx.data.configs import TRLConfig
+from trlx.data.ilql_types import ILQLBatch
 from trlx.trainer import register_trainer
 from trlx.trainer.accelerate_base_trainer import AccelerateRLTrainer
-from trlx.trainer.nn.ilql_models import ILQLConfig, CausalLMWithValueHeads
-from trlx.data.ilql_types import ILQLBatch
-from trlx.data.configs import TRLConfig
+from trlx.trainer.nn.ilql_models import CausalLMWithValueHeads, ILQLConfig
 from trlx.utils import to_device
 
 

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -1,5 +1,7 @@
+import json
+import os
+import uuid
 from typing import Tuple
-import uuid, os, json
 
 import torch
 from torchtyping import TensorType
@@ -7,14 +9,14 @@ from torchtyping import TensorType
 from trlx.data.configs import TRLConfig
 from trlx.data.ppo_types import PPORLBatch
 from trlx.pipeline.ppo_pipeline import PPORolloutStorage
-from trlx.utils.modeling import logprobs_from_logits
 from trlx.trainer import register_trainer
 from trlx.trainer.accelerate_base_trainer import AccelerateRLTrainer
 from trlx.trainer.nn.ppo_models import (
     AdaptiveKLController,
-    FixedKLController,
     CausalLMHydraWithValueHead,
+    FixedKLController,
 )
+from trlx.utils.modeling import logprobs_from_logits
 
 
 @register_trainer

--- a/trlx/trainer/nn/ilql_models.py
+++ b/trlx/trainer/nn/ilql_models.py
@@ -1,22 +1,10 @@
 import inspect
 import os
-from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import reduce
 from itertools import chain
-from typing import Any, Dict, Union, Sequence
-
-from trlx.data.ilql_types import ILQLBatch
-from trlx.data.method_configs import register_method, MethodConfig
-from trlx.utils.modeling import (
-    freeze_bottom_causal_layers,
-    hf_get_causal_base_model,
-    hf_get_hidden_size,
-    hf_get_lm_head,
-    make_head,
-)
-
+from typing import Any, Dict, Union
 
 import deepspeed  # type: ignore
 import numpy as np
@@ -24,6 +12,16 @@ import torch
 import torch.nn.functional as F
 import transformers
 from torch import nn
+
+from trlx.data.ilql_types import ILQLBatch
+from trlx.data.method_configs import MethodConfig, register_method
+from trlx.utils.modeling import (
+    freeze_bottom_causal_layers,
+    hf_get_causal_base_model,
+    hf_get_hidden_size,
+    hf_get_lm_head,
+    make_head,
+)
 
 
 def topk_mask(xs: torch.FloatTensor, k: int):

--- a/trlx/trainer/nn/ppo_models.py
+++ b/trlx/trainer/nn/ppo_models.py
@@ -15,6 +15,7 @@ from transformers.models.opt import modeling_opt
 from trlx.data.method_configs import MethodConfig, register_method
 from trlx.utils.modeling import (
     flatten_dict,
+    get_tensor_stats,
     hf_get_causal_base_model,
     hf_get_causal_final_norm,
     hf_get_causal_hidden_layers,
@@ -23,9 +24,7 @@ from trlx.utils.modeling import (
     hf_get_num_hidden_layers,
     make_head,
     whiten,
-    get_tensor_stats,
 )
-
 
 # KL Controllers
 

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -3,7 +3,7 @@ from typing import Callable, Iterable, List, Optional, Tuple
 
 from trlx.data.configs import TRLConfig
 from trlx.utils import set_seed
-from trlx.utils.loading import get_trainer, get_orchestrator, get_pipeline
+from trlx.utils.loading import get_orchestrator, get_pipeline, get_trainer
 
 
 def train(

--- a/trlx/utils/loading.py
+++ b/trlx/utils/loading.py
@@ -9,7 +9,7 @@ from trlx.orchestrator.ppo_orchestrator import PPOOrchestrator
 from trlx.pipeline import _DATAPIPELINE
 from trlx.pipeline.offline_pipeline import PromptPipeline
 
-# Register load models via module import
+# Register load trainers via module import
 from trlx.trainer import _TRAINERS
 from trlx.trainer.accelerate_ilql_trainer import AccelerateILQLTrainer
 from trlx.trainer.accelerate_ppo_trainer import AcceleratePPOTrainer

--- a/trlx/utils/loading.py
+++ b/trlx/utils/loading.py
@@ -1,10 +1,5 @@
 from typing import Callable
 
-# Register load models via module import
-from trlx.trainer import _TRAINERS
-from trlx.trainer.accelerate_ilql_trainer import AccelerateILQLTrainer
-from trlx.trainer.accelerate_ppo_trainer import AcceleratePPOTrainer
-
 # Register load orchestrators via module import
 from trlx.orchestrator import _ORCH
 from trlx.orchestrator.offline_orchestrator import OfflineOrchestrator
@@ -13,6 +8,11 @@ from trlx.orchestrator.ppo_orchestrator import PPOOrchestrator
 # Register load pipelines via module import
 from trlx.pipeline import _DATAPIPELINE
 from trlx.pipeline.offline_pipeline import PromptPipeline
+
+# Register load models via module import
+from trlx.trainer import _TRAINERS
+from trlx.trainer.accelerate_ilql_trainer import AccelerateILQLTrainer
+from trlx.trainer.accelerate_ppo_trainer import AcceleratePPOTrainer
 
 
 def get_trainer(name: str) -> Callable:

--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -1,13 +1,12 @@
+import functools
 from typing import MutableMapping, Tuple, Union
 
-import functools
+import numpy as np
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.distributed as dist
 import transformers
-from typing import Tuple
-import numpy as np
 
 
 def make_head(n_embd: int, out: int) -> nn.Sequential:


### PR DESCRIPTION
This PR adds the following `pre-commit` updates:

* ~~Update `pre-commit-hook` to a more recent version.~~
* Adds `black` formatting to `tests` directory as it was never updated for the name change from `unittests`➡️`tests`
* Adds `isort` to the pre-commit action runner. This is to avoid waiting on #39 for the more involved `flake8` checks which will require working around `torchtyping`.