### PR TITLE
More flexible way to initialize models

### DIFF
--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -27,7 +27,7 @@ class PPOOrchestrator(Orchestrator):
         reward_fn: Callable,
         metric_fn: Optional[Callable] = None,
         chunk_size: int = 512,
-        ref_model_provider: Callable = None,
+        model_provider: Callable = None,
     ):
         self.pipeline = pipeline
         self.trainer = trainer
@@ -39,8 +39,8 @@ class PPOOrchestrator(Orchestrator):
         self.pipeline_loader = self.trainer.accelerator.prepare(self.pipeline_loader)
         self.pipeline_iterator = iter(self.pipeline_loader)
 
-        if ref_model_provider is not None:
-            self.ref_model = ref_model_provider(self.trainer.config.model.model_path)
+        if model_provider is not None:
+            self.ref_model = model_provider(self.trainer.config, adapters=False)
         elif not hasattr(self.trainer.model, "frozen_head"):
             self.ref_model = self.trainer.get_arch(self.trainer.config)
 

--- a/trlx/trainer/__init__.py
+++ b/trlx/trainer/__init__.py
@@ -37,7 +37,7 @@ def register_trainer(name):
 
 @register_trainer
 class BaseRLTrainer:
-    def __init__(self, config: TRLConfig, train_mode=False):
+    def __init__(self, config: TRLConfig, train_mode=False, **kwargs):
         self.store: BaseRolloutStore = None
         self.config = config
         self.train_mode = train_mode

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -38,7 +38,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
     RL model trainer with an `accelerate` based backend
     """
 
-    def __init__(self, config, train_mode=True):
+    def __init__(self, config, train_mode=True, **kwargs):
         super().__init__(config, train_mode)
 
         self.accelerator = Accelerator(log_with=config.train.trackers)
@@ -49,7 +49,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
         self.max_length = config.train.seq_length
 
         # Retrieves model equipped for ppo, ilql, etc
-        self.model = self.get_arch(self.config)
+        self.model = self.get_arch(self.config, **kwargs)
         freeze_bottom_causal_layers(
             self.model.base_model, self.config.model.num_layers_unfrozen
         )

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, cast
+from typing import Callable, Optional, Sequence, Union, cast
 
 import torch
 
@@ -18,9 +18,9 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         logit_mask=None,
         metric_fn=None,
         train_mode=True,
-        **kwargs,
+        model_provider: Optional[Callable] = None,
     ):
-        super().__init__(config, train_mode, **kwargs)
+        super().__init__(config, train_mode, model_provider)
         self.logit_mask = logit_mask
         self.metric_fn = metric_fn
         self.reward_fn = None

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -18,8 +18,9 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         logit_mask=None,
         metric_fn=None,
         train_mode=True,
+        **kwargs,
     ):
-        super().__init__(config, train_mode)
+        super().__init__(config, train_mode, **kwargs)
         self.logit_mask = logit_mask
         self.metric_fn = metric_fn
         self.reward_fn = None
@@ -42,6 +43,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
             config.model.model_path,
             ilql_config=config.method,
             num_layers_unfrozen=config.model.num_layers_unfrozen,
+            **kwargs,
         )
 
     def tokenize(self, texts: Union[Sequence[str], Sequence[torch.LongTensor]]):

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -21,8 +21,8 @@ from trlx.utils.modeling import logprobs_from_logits
 
 @register_trainer
 class AcceleratePPOTrainer(AccelerateRLTrainer):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, **kwargs):
+        super().__init__(config, **kwargs)
 
         if config.train.rollout_logging_dir is not None:
             self.log_rollouts = True
@@ -54,9 +54,9 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             pad_token_id=self.tokenizer.eos_token_id,
         )
 
-    def get_arch(self, config: TRLConfig):
+    def get_arch(self, config: TRLConfig, **kwargs):
         return CausalLMHydraWithValueHead(
-            config.model.model_path, config.model.num_layers_unfrozen
+            config.model.model_path, config.model.num_layers_unfrozen, **kwargs
         )
 
     def get_model_inputs(

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -1,7 +1,7 @@
 import json
 import os
 import uuid
-from typing import Tuple
+from typing import Callable, Optional, Tuple
 
 import torch
 from torchtyping import TensorType
@@ -21,8 +21,8 @@ from trlx.utils.modeling import logprobs_from_logits
 
 @register_trainer
 class AcceleratePPOTrainer(AccelerateRLTrainer):
-    def __init__(self, config, **kwargs):
-        super().__init__(config, **kwargs)
+    def __init__(self, config, model_provider: Optional[Callable] = None):
+        super().__init__(config, model_provider)
 
         if config.train.rollout_logging_dir is not None:
             self.log_rollouts = True
@@ -54,9 +54,9 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             pad_token_id=self.tokenizer.eos_token_id,
         )
 
-    def get_arch(self, config: TRLConfig, **kwargs):
+    def get_arch(self, config: TRLConfig):
         return CausalLMHydraWithValueHead(
-            config.model.model_path, config.model.num_layers_unfrozen, **kwargs
+            config.model.model_path, config.model.num_layers_unfrozen, model_provider=self.model_provider
         )
 
     def get_model_inputs(

--- a/trlx/trainer/nn/ppo_models.py
+++ b/trlx/trainer/nn/ppo_models.py
@@ -26,10 +26,6 @@ from trlx.utils.modeling import (
     whiten,
 )
 
-TMODEL_PROVIDER = Callable[
-    [transformers.PretrainedConfig], transformers.AutoModelForCausalLM
-]
-
 # KL Controllers
 
 
@@ -306,21 +302,22 @@ class CausalLMHydraWithValueHead(nn.Module):
         self,
         config: Union[transformers.PretrainedConfig, str],
         num_layers_unfrozen: int = -1,
-        base_model_provider: Optional[TMODEL_PROVIDER] = None,
-        base_model_transformer_args: Optional[List[str]] = None,
+        model_provider: Optional[Callable] = None,
     ):
         super().__init__()
 
         if isinstance(config, str):
             self.config = transformers.AutoConfig.from_pretrained(config)
-            if base_model_provider is None:
-                base_model_provider = transformers.AutoModelForCausalLM.from_pretrained
-            self.base_model = base_model_provider(config)
+            if model_provider is None:
+                self.base_model = transformers.AutoModelForCausalLM.from_pretrained(config)
+            else:
+                self.base_model = model_provider(config, adapters=True)
         else:
             self.config = config
-            if base_model_provider is None:
-                base_model_provider = transformers.AutoModelForCausalLM.from_config
-            self.base_model = base_model_provider(config)
+            if model_provider is None:
+                self.base_model = transformers.AutoModelForCausalLM.from_config(config)
+            else:
+                self.base_model = model_provider(config, adapters=True)
 
         if not hasattr(self.base_model, "lm_head"):
             self.base_model.lm_head = hf_get_lm_head(self.base_model)
@@ -340,12 +337,9 @@ class CausalLMHydraWithValueHead(nn.Module):
                 lm_head=self.base_model.lm_head,
             )
         # Cache `transformer.forward` args for general use (avoids incompatible args across architectures)
-        if base_model_transformer_args is not None:
-            self.base_model_transformer_args = base_model_transformer_args
-        else:
-            self.base_model_transformer_args = inspect.getfullargspec(
-                self.base_model.transformer.forward
-            ).args
+        self.base_model_transformer_args = inspect.getfullargspec(
+            self.base_model.transformer.forward
+        ).args
 
     def _get_compatible_forward_kwargs(self, **kwargs) -> Dict[str, Any]:
         """Filter out arguments not supported by the specific instance of `base_model.transformer.forward`"""

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -16,6 +16,8 @@ def train(
     config: Optional[TRLConfig] = None,
     split_token: Optional[str] = None,
     logit_mask: Optional[List[List[bool]]] = None,
+    ref_model_provider: Optional[Callable] = None,
+    **kwargs,
 ):
     """
     Dispatches online or offline reinforcement training
@@ -31,6 +33,7 @@ def train(
         config (Optional[TRLConfig]): TRL configuration object to override default settings
         split_token (Optional[str]): Split samples in the dataset on prompts and continuations
         logit_mask (Optional[List]): Bigram masking matrix
+        ref_model_provider (Optional[Callable]): Function that create a reference model
     """
     if reward_fn is not None:
         if config is None:
@@ -40,7 +43,7 @@ def train(
         if model_path:
             config.model.model_path = model_path
 
-        trainer = get_trainer(config.train.trainer)(config)
+        trainer = get_trainer(config.train.trainer)(config, **kwargs)
 
         batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))
         prompts = prompts or [trainer.tokenizer.bos_token] * batch_size
@@ -55,7 +58,11 @@ def train(
             prompts, max_prompt_length, trainer.tokenizer
         )
         orch = get_orchestrator(config.train.orchestrator)(
-            trainer, pipeline, reward_fn=reward_fn, chunk_size=config.method.chunk_size
+            trainer,
+            pipeline,
+            reward_fn=reward_fn,
+            chunk_size=config.method.chunk_size,
+            ref_model_provider=ref_model_provider,
         )
         orch.make_experience(config.method.num_rollouts)
         eval_pipeline = get_pipeline(config.train.pipeline)(

--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -1,5 +1,5 @@
 import functools
-from typing import MutableMapping, Tuple, Union
+from typing import MutableMapping, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -9,12 +9,14 @@ import torch.nn.functional as F
 import transformers
 
 
-def make_head(n_embd: int, out: int) -> nn.Sequential:
+def make_head(
+    n_embd: int, out: int, dtype: Optional[Union[torch.dtype, str]] = None
+) -> nn.Sequential:
     """Returns a generic sequential MLP head."""
     return nn.Sequential(
-        nn.Linear(n_embd, n_embd * 2),
+        nn.Linear(n_embd, n_embd * 2, dtype=dtype),
         nn.ReLU(),
-        nn.Linear(n_embd * 2, out),
+        nn.Linear(n_embd * 2, out, dtype=dtype),
     )
 
 


### PR DESCRIPTION
This PR is a copy from https://github.com/CarperAI/trlx/pull/160

It contains internal changes in core codes:
- Provide base and reference models initializers
- The more flexible way to create heads on HydraModels:
  - add dtype in value head
  - find lm head if already have one