### PR TITLE
Fix wandb.errors.RequireError as reported in #162

### DIFF
--- a/configs/sweeps/ilql_sweep.yml
+++ b/configs/sweeps/ilql_sweep.yml
@@ -5,7 +5,7 @@ tune_config:
   scheduler: "fifo"
   num_samples: 32
 
-lr_init:
+lr:
   strategy: "loguniform"
   values: [0.00001, 0.01]
 tau:

--- a/configs/sweeps/ppo_sweep.yml
+++ b/configs/sweeps/ppo_sweep.yml
@@ -3,7 +3,7 @@ tune_config:
   metric: "reward/mean"
   search_alg: "random"
   scheduler: "fifo"
-  num_samples: 32
+  num_samples: 5
 
 # https://docs.ray.io/en/latest/tune/api_docs/search_space.html#tune-sample-docs
 lr:

--- a/configs/sweeps/ppo_sweep.yml
+++ b/configs/sweeps/ppo_sweep.yml
@@ -1,12 +1,12 @@
 tune_config:
   mode: "max"
-  metric: "mean_reward"
+  metric: "reward/mean"
   search_alg: "random"
   scheduler: "fifo"
   num_samples: 32
 
 # https://docs.ray.io/en/latest/tune/api_docs/search_space.html#tune-sample-docs
-lr_init:
+lr:
   strategy: "loguniform"
   values: [0.00001, 0.01]
 init_kl_coef:

--- a/configs/sweeps/ppo_sweep.yml
+++ b/configs/sweeps/ppo_sweep.yml
@@ -3,7 +3,7 @@ tune_config:
   metric: "reward/mean"
   search_alg: "random"
   scheduler: "fifo"
-  num_samples: 5
+  num_samples: 32
 
 # https://docs.ray.io/en/latest/tune/api_docs/search_space.html#tune-sample-docs
 lr:

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -48,7 +48,7 @@ def main(hparams={}):
     imdb = load_dataset("imdb", split="test")
     val_prompts = [" ".join(review.split()[:4]) for review in imdb["text"]]
 
-    return trlx.train(
+    trlx.train(
         reward_fn=reward_fn,
         prompts=prompts,
         eval_prompts=val_prompts[0:1000],

--- a/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py
+++ b/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         )  # get prompt like trlx's prompt
         prompt_label[key.strip()] = val_summaries[i]
 
-    model = trlx.train(
+    trlx.train(
         config.model.model_path,
         reward_fn=reward_fn,
         prompts=prompts,

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     torchtyping
     transformers>=4.21.2
     tqdm
-    wandb
+    wandb>=0.13.5
     ray>=2.0.1
     tabulate>=0.9.0
     networkx

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -5,31 +5,9 @@ import math
 import os
 from pathlib import Path
 
-import wandb
-
-
-def check_wandb_version():
-    import logging
-
-    from pkg_resources import parse_version
-
-    logger = logging.getLogger(__name__)
-
-    if parse_version(wandb.__version__) >= parse_version("0.12.21") and parse_version(
-        wandb.__version__
-    ) <= parse_version("0.13.5"):
-        wandb.require("report-editing")
-    elif parse_version(wandb.__version__) < parse_version("0.12.21"):
-        logger.info(
-            "Programmatic Reports are not supported in wandb version < 0.12.21, "
-            "please upgrade wandb to 0.12.21 or higher."
-        )
-    else:
-        pass
-
-check_wandb_version()
-
 import wandb.apis.reports as wb  # noqa: E402
+
+import wandb
 
 ray_info = [
     "done",
@@ -105,10 +83,10 @@ def log_trials(trial_path: str, project_name: str):
 def create_report(project_name, param_space, tune_config, trial_path, best_config=None):
     def get_parallel_coordinate(param_space, metric):
         column_names = list(param_space.keys())
-        columns = [wb.reports.PCColumn(column) for column in column_names]
+        columns = [wb.PCColumn(column) for column in column_names]
 
         return wb.ParallelCoordinatesPlot(
-            columns=columns + [wb.reports.PCColumn(metric)],
+            columns=columns + [wb.PCColumn(metric)],
             layout={"x": 0, "y": 0, "w": 12 * 2, "h": 5 * 2},
         )
 
@@ -176,7 +154,7 @@ def create_report(project_name, param_space, tune_config, trial_path, best_confi
                 get_scatter_plot(tune_config["metric"]),
             ],
             runsets=[
-                wb.RunSet(project=project_name).set_filters_with_python_expr(
+                wb.Runset(project=project_name).set_filters_with_python_expr(
                     f'group == "{trial_path}"'
                 )
             ],
@@ -213,7 +191,7 @@ def create_report(project_name, param_space, tune_config, trial_path, best_confi
         wb.PanelGrid(
             panels=line_plot_panels,
             runsets=[
-                wb.RunSet(project=project_name).set_filters_with_python_expr(
+                wb.Runset(project=project_name).set_filters_with_python_expr(
                     f'group == "{trial_path}"'
                 )
             ],

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -5,9 +5,9 @@ import math
 import os
 from pathlib import Path
 
+import wandb
 import wandb.apis.reports as wb  # noqa: E402
 
-import wandb
 
 ray_info = [
     "done",

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -7,7 +7,27 @@ from pathlib import Path
 
 import wandb
 
-wandb.require("report-editing")
+
+def check_wandb_version():
+    import logging
+
+    from pkg_resources import parse_version
+
+    logger = logging.getLogger(__name__)
+
+    if parse_version(wandb.__version__) >= parse_version("0.12.21") and parse_version(
+        wandb.__version__
+    ) <= parse_version("0.13.5"):
+        wandb.require("report-editing")
+    elif parse_version(wandb.__version__) < parse_version("0.12.21"):
+        logger.info(
+            "Programmatic Reports are not supported in wandb version < 0.12.21, "
+            "please upgrade wandb to 0.12.21 or higher."
+        )
+    else:
+        pass
+
+
 import wandb.apis.reports as wb  # noqa: E402
 
 ray_info = [

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -27,6 +27,7 @@ def check_wandb_version():
     else:
         pass
 
+check_wandb_version()
 
 import wandb.apis.reports as wb  # noqa: E402
 

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -6,7 +6,8 @@ import os
 from pathlib import Path
 
 import wandb
-import wandb.apis.reports as wb  # noqa: E402
+
+import wandb.apis.reports as wb  # isort: skip
 
 
 ray_info = [

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -221,7 +221,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
         prompts_sizes = []
         lst_prompts = []
         generate_time = time()
-        for prompts in tqdm(self.eval_dataloader, desc="Generating samples"):
+        for prompts in self.eval_dataloader:
             if isinstance(prompts, torch.Tensor):
                 samples = self.generate_eval(prompts)
             else:


### PR DESCRIPTION
This PR checks for the `wandb` version to ensure `wandb.require("report-editing")` is used with the right version.

For `wandb` version > 0.13.5 `wandb.require` is not required and for `wandb` version < 0.12.21` it is not supported. 

This PR is to fix the original issue raised in #162 by @asmith26. 