### PR TITLE
Fix default `delta_kwargs` handling

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,8 +95,8 @@ def test_hf_attr_getters(model_name: str):
     [
         "EleutherAI/gpt-j-6B",
         "EleutherAI/gpt-neox-20b",
-        "gpt2",
         "facebook/opt-1.3b",
+        "bigscience/bloom-560m",
     ],
 )
 def test_parse_delta_kwargs(model_name):

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -36,19 +36,20 @@ class ModelConfig:
     :param delta_kwargs: Keyword arguments for instantiating OpenDelta models for delta-tuning.
         Follow the `OpenDelta.AutoDeltaConfig` specification, e.g. for LoRA style tuning, set
         the `delta_type` to `lora` and include the model specific hyper-parameters (e.g. `lora_a`)
-            {"delta_type": "lora", "lora_a": 0.5}
+            {"delta_type": "lora", "modified_modules": "all", "lora_a": 0.5}
         or in YAML format:
             delta_kwargs:
                 delta_type: lora
+                modified_modules: "all"
                 lora_a: 0.5
         See: https://opendelta.readthedocs.io/en/latest/modules/auto_delta.html#opendelta.auto_delta.AutoDeltaConfig
-    :type delta_kwargs: Dict[str, Any]
+    :type delta_kwargs: Optional[Dict[str, Any]]
     """
 
     model_path: str
     tokenizer_path: str
     num_layers_unfrozen: int = -1
-    delta_kwargs: Dict[str, Any] = field(default_factory=dict)
+    delta_kwargs: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):
@@ -128,6 +129,7 @@ class TrainConfig:
     :type orchestrator: str
 
     :param trainer: Trainer to use for training. One of the registered trainers present in trlx.trainer
+    :type trainer: str
 
     :param project_name: Project name for wandb
     :type project_name: str

--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -260,11 +260,6 @@ class RunningMoments:
 
 
 MODIFIED_MODULES_DICT = {
-    "gpt2": {
-        "attention": ["attn.c_attn", "attn.c_proj"],
-        "mlp": ["mlp.c_fc", "mlp.c_proj"],
-        "all": ["attn.c_attn", "attn.c_proj", "mlp.c_fc", "mlp.c_proj"],
-    },
     "gptj": {
         "attention": ["attn.q_proj", "attn.k_proj", "attn.v_proj"],
         "mlp": ["mlp.fc_in", "mlp.fc_out"],
@@ -335,7 +330,7 @@ def generate_layer_regex(
 
 def get_delta_modified_modules(
     config: transformers.PretrainedConfig,
-    modified_modules: str,
+    modified_modules: List[str],
     num_layers_unfrozen: int = -1,
 ) -> List[str]:
     """Returns a list of module names to be modified for a given delta method with
@@ -364,9 +359,9 @@ def parse_delta_kwargs(
     config: transformers.PretrainedConfig,
     delta_kwargs: Dict[str, Any],
     num_layers_unfrozen: int = -1,
-) -> Tuple[str, Dict[str, any]]:
+) -> Tuple[str, Dict[str, Any]]:
     """Parses through delta kwargs to get delta type and proper modified modules."""
-    # This is function is needed to parse through the `delta_kwargs` to:
+    # This function is needed to parse through the `delta_kwargs` in order to:
     # 1) Get the `delta_type` method name to access the correct `delta_model_class`
     # 2a) Accept user specified `modified_modules` and if not provided use the `trlx` default mapping
     # 2b) Convert the list of `modified_modules` to a range of layers that fit within the range
@@ -380,6 +375,11 @@ def parse_delta_kwargs(
     # Use `trlx` default modified modules if none are specified
     modified_modules = delta_kwargs.get("modified_modules", "all")
     if modified_modules in ["all", "attention", "mlp"]:
+        if config.model_type not in MODIFIED_MODULES_DICT:
+            raise ValueError(
+                f"Model type `{config.model_type}` is not currently supported for "
+                "delta training with default modified modules."
+            )
         modified_modules = MODIFIED_MODULES_DICT[config.model_type][modified_modules]
     # Update the `modified_modules` with the correct layer ranges
     delta_kwargs["modified_modules"] = get_delta_modified_modules(


### PR DESCRIPTION
* Makes `delta_kwargs` an optional config; previously it defaulted to an empty `dict` which breaks the delta handlers for runs that do not use delta-tuning. Discovered by @PhungVanDuy 

* Removes `gpt2` from the default `MODIFIED_MODULES_DICT` as its MLP layers are implemented as Conv1D layers which are not supported by the OpenDelta pacakge; see this line [here](https://github.com/thunlp/OpenDelta/blob/a25fb1b2aabb9a2ed55ca941a15b9321bb32377c/opendelta/delta_models/lora.py#L151) (Conv1D does not contain `in/out_features` attrs)