### PR TITLE
Update generation utilities

### DIFF
--- a/examples/architext.py
+++ b/examples/architext.py
@@ -6,7 +6,7 @@ import trlx
 from trlx.data.configs import TRLConfig
 
 
-def reward_fn(samples):
+def reward_fn(samples, **kwargs):
     "Gives a negative count of rooms for each sample"
     return [-sample.count(":") for sample in samples]
 

--- a/examples/ilql_sentiments.py
+++ b/examples/ilql_sentiments.py
@@ -29,7 +29,7 @@ def main(hparams={}):
         device=0 if int(os.environ.get("LOCAL_RANK", 0)) == 0 else -1,
     )
 
-    def metric_fn(samples: List[str]) -> Dict[str, List[float]]:
+    def metric_fn(samples: List[str], **kwargs) -> Dict[str, List[float]]:
         sentiments = list(map(get_positive_score, sentiment_fn(samples)))
         return {"sentiments": sentiments}
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -6,10 +6,10 @@ from typing import List
 
 import torch
 import yaml
+from datasets import load_dataset
 from transformers import pipeline
 
 import trlx
-from datasets import load_dataset
 from trlx.data.configs import TRLConfig
 
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -6,10 +6,10 @@ from typing import List
 
 import torch
 import yaml
-from datasets import load_dataset
 from transformers import pipeline
 
 import trlx
+from datasets import load_dataset
 from trlx.data.configs import TRLConfig
 
 
@@ -38,7 +38,7 @@ def main(hparams={}):
         device=device,
     )
 
-    def reward_fn(samples: List[str]) -> List[float]:
+    def reward_fn(samples: List[str], **kwargs) -> List[float]:
         sentiments = list(map(get_positive_score, sentiment_fn(samples)))
         return sentiments
 

--- a/examples/randomwalks/configs/ilql_randomwalks.yml
+++ b/examples/randomwalks/configs/ilql_randomwalks.yml
@@ -43,6 +43,6 @@ method:
   two_qs: true
   gen_kwargs:
     max_new_tokens: 9
-    top_k: 1
-    beta: 100
+    top_k: 10
+    beta: [0, 1, 100]
     temperature: 1.0

--- a/examples/randomwalks/ilql_randomwalks.py
+++ b/examples/randomwalks/ilql_randomwalks.py
@@ -21,7 +21,7 @@ def main(hparams={}):
         GPT2Config(n_layer=6, n_embd=144, vocab_size=23),
         dataset=(walks, rewards),
         eval_prompts=eval_prompts,
-        metric_fn=metric_fn,
+        metric_fn=lambda samples, **kwargs: metric_fn(samples),
         config=config,
     )
 

--- a/examples/randomwalks/ilql_randomwalks.py
+++ b/examples/randomwalks/ilql_randomwalks.py
@@ -25,6 +25,7 @@ def main(hparams={}):
         eval_prompts=eval_prompts,
         metric_fn=lambda samples, **kwargs: metric_fn(samples),
         config=config,
+        stop_sequences=["|"],
     )
 
 

--- a/examples/randomwalks/ppo_randomwalks.py
+++ b/examples/randomwalks/ppo_randomwalks.py
@@ -20,7 +20,7 @@ def main(hparams={}):
         reward_fn=lambda samples, **kwargs: metric_fn(samples)["optimality"],
         prompts=prompts,
         eval_prompts=prompts,
-        metric_fn=metric_fn,
+        metric_fn=lambda samples, **kwargs: metric_fn(samples),
         config=config,
     )
 

--- a/examples/randomwalks/ppo_randomwalks.py
+++ b/examples/randomwalks/ppo_randomwalks.py
@@ -17,7 +17,7 @@ def main(hparams={}):
 
     trlx.train(
         "CarperAI/randomwalks",
-        reward_fn=lambda walks: metric_fn(walks)["optimality"],
+        reward_fn=lambda samples, **kwargs: metric_fn(samples)["optimality"],
         prompts=prompts,
         eval_prompts=prompts,
         metric_fn=metric_fn,

--- a/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py
+++ b/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py
@@ -25,16 +25,14 @@ meteor = evaluate.load("meteor")  # use meteor as the reward function
 
 if __name__ == "__main__":
 
-    def reward_fn(samples: List[str]):
-        sep_token = tokenizer.sep_token
-        articles = [sample.split(sep_token)[0].strip() for sample in samples]
-        predicted_summaries = [sample.split(sep_token)[1].strip() for sample in samples]
-        labels = [prompt_label[sample] for sample in articles]
+    def reward_fn(samples: List[str], prompts: List[str], outputs: List[str]):
+        original_summaries = [prompt_label[prompt.strip()] for prompt in prompts]
         scores = [
-            meteor.compute(predictions=[summary], references=[label])
-            for (summary, label) in zip(predicted_summaries, labels)
+            meteor.compute(predictions=[output.strip()], references=[original])[
+                "meteor"
+            ]
+            for (original, output) in zip(original_summaries, outputs)
         ]
-        scores = [score["meteor"] for score in scores]
         return scores
 
     dataset = load_dataset("cnn_dailymail", "3.0.0", cache_dir="data")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     torchtyping
     transformers>=4.21.2
     tqdm
+    rich
     wandb>=0.13.5
     ray>=2.0.1
     tabulate>=0.9.0

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -61,9 +61,6 @@ class PPOOrchestrator(Orchestrator):
         stats = {}
         clock = Clock()
         while len(ppo_rl_elements) < num_rollouts:
-            if self.trainer.accelerator.is_main_process:
-                print(f"Making experience {len(ppo_rl_elements)} / {num_rollouts}")
-
             # Get next batch in prompt dataset and refresh if exhausted
             try:
                 batch: PromptBatch = next(self.pipeline_iterator)

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -82,7 +82,16 @@ class PPOOrchestrator(Orchestrator):
             )
             exp_score_time = time()
             scores = torch.tensor(
-                self.score(texts), device=samples.device, dtype=torch.float
+                self.trainer.reward_fn(
+                    samples=texts,
+                    prompts=self.trainer.tokenizer.batch_decode(
+                        query_tensors, skip_special_tokens=True
+                    ),
+                    outputs=self.trainer.tokenizer.batch_decode(
+                        response_tensors, skip_special_tokens=True
+                    ),
+                ),
+                dtype=float,
             )
             stats["time/exp_score"] = time() - exp_score_time
 

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -80,7 +80,7 @@ class PPOOrchestrator(Orchestrator):
             self.trainer.tokenizer.padding_side = "right"
             response_tensors = self.trainer.tokenizer(
                 str_outputs, padding=True, return_tensors="pt"
-            ).input_ids.to(query_tensors.device)
+            ).input_ids.to(samples.device)
             self.trainer.tokenizer.padding_side = "left"
 
             exp_score_time = time()
@@ -92,7 +92,7 @@ class PPOOrchestrator(Orchestrator):
                     outputs=str_outputs,
                 ),
                 dtype=float,
-            )
+            ).to(samples.device)
             stats["time/exp_score"] = time() - exp_score_time
 
             # store statistics of the initial rollout as reference

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -82,7 +82,7 @@ class PPOOrchestrator(Orchestrator):
             # This can be defered, instead letting the pass to made over the original samples
             # after unbinding and truncating operations lower are fixed
             outputs = self.trainer.tokenizer(str_outputs).input_ids
-            outputs = list(map(torch.IntTensor, outputs))
+            outputs = list(map(torch.LongTensor, outputs))
             maxsize = max(map(len, outputs))
             outputs = [
                 F.pad(
@@ -126,7 +126,6 @@ class PPOOrchestrator(Orchestrator):
 
             # Precompute logprobs, values
             if self.trainer.config.model.model_arch_type == "seq2seq":
-                response_tensors = response_tensors
                 attention_mask = batch.attention_mask.to(device)
                 query_tensors = batch.input_ids.to(device)
                 with torch.no_grad():

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import wandb
+from trlx.utils import significant
 
 import wandb.apis.reports as wb  # isort: skip
 
@@ -37,10 +38,6 @@ def parse_result(result):
             out[k] = v
 
     return out
-
-
-def significant(x):
-    return round(x, 1 - int(math.floor(math.log10(x))))
 
 
 def log_trials(trial_path: str, project_name: str):

--- a/trlx/ray_tune/wandb.py
+++ b/trlx/ray_tune/wandb.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 import wandb
+
 from trlx.utils import significant
 
 import wandb.apis.reports as wb  # isort: skip

--- a/trlx/trainer/__init__.py
+++ b/trlx/trainer/__init__.py
@@ -42,8 +42,8 @@ class BaseRLTrainer:
         config: TRLConfig,
         reward_fn=None,
         metric_fn=None,
-        stop_word=None,
         logit_mask=None,
+        stop_sequences=None,
         train_mode=False,
     ):
         self.store: BaseRolloutStore = None
@@ -51,8 +51,8 @@ class BaseRLTrainer:
         self.reward_fn = reward_fn
         self.metric_fn = metric_fn
         self.train_mode = train_mode
-        self.stop_word = stop_word
         self.logit_mask = logit_mask
+        self.stop_sequences = stop_sequences
 
     def push_to_store(self, data):
         self.store.push(data)

--- a/trlx/trainer/__init__.py
+++ b/trlx/trainer/__init__.py
@@ -37,10 +37,22 @@ def register_trainer(name):
 
 @register_trainer
 class BaseRLTrainer:
-    def __init__(self, config: TRLConfig, train_mode=False):
+    def __init__(
+        self,
+        config: TRLConfig,
+        reward_fn=None,
+        metric_fn=None,
+        stop_word=None,
+        logit_mask=None,
+        train_mode=False,
+    ):
         self.store: BaseRolloutStore = None
         self.config = config
+        self.reward_fn = reward_fn
+        self.metric_fn = metric_fn
         self.train_mode = train_mode
+        self.stop_word = stop_word
+        self.logit_mask = logit_mask
 
     def push_to_store(self, data):
         self.store.push(data)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -259,7 +259,12 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 # in online setting, compute the reward for validation
                 if self.reward_fn:
                     rewards = torch.tensor(
-                        self.reward_fn(str_samples), dtype=torch.float
+                        self.reward_fn(
+                            samples=str_samples,
+                            prompts=str_prompts,
+                            responses=str_responses,
+                        ),
+                        dtype=float,
                     )
                     mean_reward = rewards.mean()
                     columns.append("reward")
@@ -270,7 +275,11 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 # additionally log any other metrics
                 if self.metric_fn:
                     metric_time = time()
-                    metrics = self.metric_fn(str_samples)
+                    metrics = self.metric_fn(
+                        samples=str_samples,
+                        prompts=str_prompts,
+                        responses=str_responses,
+                    )
                     stats["time/metric"] = time() - metric_time
 
                     mean_metrics = {

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -164,10 +164,10 @@ class AccelerateRLTrainer(BaseRLTrainer):
         )
 
     def decode(
-        self, prompts: List[torch.IntTensor], samples, prompt_sizes=None
-    ) -> List[str]:
+        self, prompts: List[torch.LongTensor], samples: List[torch.LongTensor], prompt_sizes: torch.LongTensor=None
+    ) -> Tuple[List[str], List[str], List[str]]:
         """
-        Decode samples into (samples: List[str], outputs: List[str], samples: List[str])
+        Decode tensor generations into lists of strings (`samples`: List[str], `prompts`: List[str], `outputs`: List[str])
         """
         if prompt_sizes is None:
             # Assuming prompts were left-padded
@@ -187,7 +187,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 sample[output_start_ix:], skip_special_tokens=True
             )
 
-            # Trim outputs up to `self.stop` if present
+            # Trim outputs up to `self.stop_sequences` if any are present
             if self.stop_sequences:
                 for stop in self.stop_sequences:
                     stop_ix = str_output.find(stop)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 import os
 import sys
@@ -6,21 +5,16 @@ from abc import abstractmethod
 from time import time
 from typing import Dict, List, Sequence, Tuple, Union
 
+import ray
 import torch
 import torch.nn.functional as F
 from accelerate import Accelerator  # type: ignore
-from transformers import AutoTokenizer
-
-if importlib.util.find_spec("rich") is not None:
-    from tqdm.rich import tqdm
-else:
-    from tqdm import tqdm
-
-import ray
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
 from rich.console import Console
 from rich.table import Table
+from tqdm import tqdm
+from transformers import AutoTokenizer
 
 from trlx.data.configs import TRLConfig
 from trlx.trainer import BaseRLTrainer, register_trainer

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -192,7 +192,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
         if self.generate_sweep_kwarg is not None:
             gen_sweep_arg, gen_sweep_values = self.generate_sweep_kwarg
         else:
-            gen_sweep_values = [None]
+            gen_sweep_arg, gen_sweep_values = "_", [None]
 
         for gen_sweep_value in gen_sweep_values:
             if gen_sweep_value is not None:

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -3,7 +3,7 @@ import os
 import sys
 from abc import abstractmethod
 from time import time
-from typing import Dict, List, Sequence, Tuple, Union
+from typing import Optional, Dict, List, Sequence, Tuple, Union
 
 import ray
 import torch
@@ -31,7 +31,6 @@ from trlx.utils.modeling import (
     get_delta_model_class,
     parse_delta_kwargs,
 )
-
 
 @register_trainer
 class AccelerateRLTrainer(BaseRLTrainer):

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -320,22 +320,14 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
                 # in online setting, compute the reward for validation
                 if self.reward_fn:
-                    if self.config.model.model_arch_type == "seq2seq":
-                        sep_token = self.tokenizer.sep_token
-                        texts = [
-                            f"{article}{sep_token}{response}"
-                            for article, response in zip(str_prompts, str_samples)
-                        ]
-                        rewards = torch.tensor(self.reward_fn(texts), dtype=torch.float)
-                    else:
-                        rewards = torch.tensor(
-                            self.reward_fn(
-                                samples=str_samples,
-                                prompts=str_prompts,
-                                responses=str_responses,
-                            ),
-                            dtype=float,
-                        )
+                    rewards = torch.tensor(
+                        self.reward_fn(
+                            samples=str_samples,
+                            prompts=str_prompts,
+                            responses=str_responses,
+                        ),
+                        dtype=float,
+                    )
                     mean_reward = rewards.mean()
                     columns.append("reward")
                     columns_data.append(rewards)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -187,12 +187,12 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 sample[output_start_ix:], skip_special_tokens=True
             )
 
-            # Trim outputs up to `self.stop_word` if present
-            if self.stop_word:
-                stop_word_ix = str_output.find(self.stop_word)
-                if stop_word_ix == -1:
-                    stop_word_ix = None
-                str_output = str_output[:stop_word_ix]
+            # Trim outputs up to `self.stop` if present
+            if self.stop_sequences:
+                for stop in self.stop_sequences:
+                    stop_ix = str_output.find(stop)
+                    if stop_ix >= 0:
+                        str_output = str_output[:stop_ix].rstrip()
 
             str_prompts.append(str_prompt)
             str_outputs.append(str_output)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -245,7 +245,6 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 if self.config.model.model_arch_type == "seq2seq":
                     pad_token = self.tokenizer.pad_token_id
                     all_samples.extend(samples[:, 1:])
-                    lst_prompts.extend(prompts.input_ids)
                 else:
                     pad_token = self.tokenizer.eos_token_id if self.tokenizer else 0
                     all_samples.append(
@@ -255,12 +254,13 @@ class AccelerateRLTrainer(BaseRLTrainer):
                             value=pad_token,
                         )
                     )
-                    sizes = torch.tensor(prompts.input_ids.shape[1]).repeat(
-                        len(prompts.input_ids)
-                    )
-                    prompts_sizes.append(sizes.to(samples.device))
+                sizes = torch.tensor(prompts.input_ids.shape[1]).repeat(
+                    len(prompts.input_ids)
+                )
+                prompts_sizes.append(sizes.to(samples.device))
+                lst_prompts.extend(prompts.input_ids)
 
-                stats["time/generate"] = time() - generate_time
+            stats["time/generate"] = time() - generate_time
 
             if self.config.model.model_arch_type == "seq2seq":
                 samples = all_samples

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -24,6 +24,7 @@ from trlx.utils import (
     get_git_tag,
     get_optimizer_class,
     get_scheduler_class,
+    print_rank_0
 )
 from trlx.utils.modeling import (
     freeze_bottom_causal_layers,
@@ -390,7 +391,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
         for k, v in self.config.method.gen_kwargs.items():
             if isinstance(v, list):
                 if self.generate_sweep_kwarg is not None:
-                    print(
+                    print_rank_0(
                         "Only a single sweep is allowed, {k} is going to be set to {v[0]}"
                     )
                     self.generate_kwargs[k] = v[0]

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -12,17 +12,8 @@ from trlx.utils import to_device
 
 @register_trainer
 class AccelerateILQLTrainer(AccelerateRLTrainer):
-    def __init__(
-        self,
-        config: TRLConfig,
-        logit_mask=None,
-        metric_fn=None,
-        train_mode=True,
-    ):
-        super().__init__(config, train_mode)
-        self.logit_mask = logit_mask
-        self.metric_fn = metric_fn
-        self.reward_fn = None
+    def __init__(self, config: TRLConfig, **kwargs):
+        super().__init__(config, **kwargs)
 
         if not isinstance(config.method, ILQLConfig):
             raise ValueError("config.method must be ILQLConfig")

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -22,8 +22,8 @@ from trlx.utils.modeling import logprobs_from_logits
 
 @register_trainer
 class AcceleratePPOTrainer(AccelerateRLTrainer):
-    def __init__(self, config):
-        super().__init__(config)
+    def __init__(self, config, **kwargs):
+        super().__init__(config, **kwargs)
 
         if config.train.rollout_logging_dir is not None:
             self.log_rollouts = True

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -19,7 +19,7 @@ def train(
     ] = None,
     config: Optional[TRLConfig] = None,
     logit_mask: Optional[List[List[bool]]] = None,
-    stop_word: Optional[str] = "",
+    stop_sequences: Optional[List[str]] = [],
 ):
     """
     Dispatches online or offline reinforcement training
@@ -43,8 +43,9 @@ def train(
             as metric's name and values and lists of numeric values per each sample in batch
         config (Optional[TRLConfig]): TRL configuration object to override default settings
         logit_mask (Optional[List]): Bigram masking matrix
-        stop_word (Optional[str]): A string to trim generations (either for experience or evaluation) up to
-            its encounter in them
+        stop_sequences (Optional[List[str]]):
+            String sequences to trim generations (either for experience or evaluation) up to its
+            encounter in them. Generatations will not contain them and also will be right-stripped
     """
 
     if reward_fn is not None:
@@ -56,7 +57,10 @@ def train(
             config.model.model_path = model_path
 
         trainer = get_trainer(config.train.trainer)(
-            config=config, reward_fn=reward_fn, metric_fn=metric_fn, stop_word=stop_word
+            config=config,
+            reward_fn=reward_fn,
+            metric_fn=metric_fn,
+            stop_sequences=stop_sequences
         )
 
         batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))
@@ -99,8 +103,8 @@ def train(
         trainer = get_trainer(config.train.trainer)(
             config=config,
             metric_fn=metric_fn,
-            stop_word=stop_word,
             logit_mask=logit_mask,
+            stop_sequences=stop_sequences,
         )
         batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))
         max_prompt_length = (

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -60,7 +60,7 @@ def train(
             config=config,
             reward_fn=reward_fn,
             metric_fn=metric_fn,
-            stop_sequences=stop_sequences
+            stop_sequences=stop_sequences,
         )
 
         batch_size = config.train.batch_size * int(os.environ.get("WORLD_SIZE", 1))

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -1,9 +1,11 @@
+import math
 import os
 import random
 import subprocess
 import time
 from dataclasses import is_dataclass
 from enum import Enum
+from numbers import Number
 from typing import Dict, Iterable
 
 import numpy as np
@@ -19,6 +21,19 @@ def print_rank_0(*message):
     """
     if os.environ.get("RANK", "0") == "0":
         print(*message)
+
+
+def significant(x: Number, ndigits=2) -> Number:
+    """
+    Cut the number up to its `ndigits` after the most significant
+    """
+    if isinstance(x, torch.Tensor):
+        x = x.item()
+
+    if not isinstance(x, Number) or x == 0:
+        return x
+
+    return round(x, ndigits - int(math.floor(math.log10(abs(x)))))
 
 
 def set_seed(seed: int):

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -261,4 +261,4 @@ def get_git_tag() -> str:
     """
     output = subprocess.check_output("git log --format='%h/%as' -n1".split())
     branch = subprocess.check_output("git rev-parse --abbrev-ref HEAD".split())
-    return f"{branch.decode()[:-1]}/{output.decode()[1:-2]}"
+    return branch.decode()[:-1], output.decode()[1:-2]


### PR DESCRIPTION
This PR will
- [x] enable sweeping over a single `gen_kwargs` value (e.g. `temperature`, `top_k`, `beta`) during periodic evaluations
- [x] change `reward_fn`'s signature from `reward_fn(samples)` to `reward_fn(samples, prompts, responses)`
- [x] add an optional stop keyword to `gen_kwargs` (e.g. Models indicate they have completed a response by generating a stop sequence, which is literally the string "Human:" – from Anthropic's 2021 "A General Language Assistant as a Laboratory for Alignment")
- [x] clean up evaluation result's outputs

Among HF's `generate` arguments `StoppingCriteria` can only stop all generations per batch, `eos_token_ids` accepts only `List[int]`. The other option is to customize `generate` method for every architecture or to trim samples after `generate` as was done here

https://wandb.ai/sorry/trlx/reports/-Update-generation-utilities-172---VmlldzozMzIxMjE1
https://wandb.ai/sorry/trlx/reports/Update-generation-utilities-172--VmlldzozMzIxMjE5