### PR TITLE
Add `wandb` group naming

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -141,6 +141,9 @@ class TrainConfig:
     :param entity_name: Entity name for wandb
     :type entity_name: str
 
+    :param group_name: Group name for wandb (used for grouping runs)
+    :type group_name: str
+
     :param checkpoint_dir: Directory to save checkpoints
     :type checkpoint_dir: str
 
@@ -169,6 +172,7 @@ class TrainConfig:
 
     project_name: str = "trlx"
     entity_name: Optional[str] = None
+    group_name: Optional[str] = None
 
     checkpoint_dir: str = "ckpts"
     rollout_logging_dir: Optional[str] = None

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -83,6 +83,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 init_trackers_kwargs["wandb"] = {
                     "name": run_name,
                     "entity": self.config.train.entity_name,
+                    "group": self.config.train.group_name,
                     "tags": ["/".join(get_git_tag())],
                     "mode": "disabled" if os.environ.get("debug", False) else "online",
                 }


### PR DESCRIPTION
* Adds the `group_name` option to training configs for `wandb` tracking. See the `Groups` filter in the project [here](https://wandb.ai/carperai/trlx).
* Related issue: #186

(Photo for quick viewing)

  <img width="1151" alt="Screenshot 2023-01-13 at 13 40 17" src="https://user-images.githubusercontent.com/41410219/212394836-d1aa2dd6-5fb0-4595-ab4a-5c569645f8a6.png">
