### PR TITLE
Update `reward_fn` signatures in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can train a model using a reward function or a reward-labeled dataset.
 
 #### Using a reward function
 ```python
-trainer = trlx.train('gpt2', reward_fn=lambda samples: [sample.count('cats') for sample in samples])
+trainer = trlx.train('gpt2', reward_fn=lambda samples, **kwargs: [sample.count('cats') for sample in samples])
 ```
 #### Using a reward-labeled dataset
 ```python

--- a/examples/experiments/grounded_program_synthesis/train_trlx.py
+++ b/examples/experiments/grounded_program_synthesis/train_trlx.py
@@ -29,7 +29,7 @@ class DSLDataset:
 interpreter = Interpreter()
 
 
-def reward_fn(samples):
+def reward_fn(samples, **kwargs):
     reward_list = []
     for sample in samples:
         code = sample.split("Function:")[1].strip()

--- a/examples/summarize_rlhf/configs/default_accelerate_config.yaml
+++ b/examples/summarize_rlhf/configs/default_accelerate_config.yaml
@@ -2,7 +2,7 @@ command_file: null
 commands: null
 compute_environment: LOCAL_MACHINE
 deepspeed_config:
-  deepspeed_config_file: ds_config_trlx_gptj_summarize.json
+  deepspeed_config_file: configs/ds_config_trlx_gptj_summarize.json
   zero3_init_flag: false
 distributed_type: DEEPSPEED
 downcast_bf16: 'no'

--- a/examples/summarize_rlhf/trlx_gptj_text_summarization.py
+++ b/examples/summarize_rlhf/trlx_gptj_text_summarization.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
             formatted_prompts.append(tmp)
         return formatted_prompts
 
-    def reward_fn(samples: List[str]):
+    def reward_fn(samples: List[str], **kwargs):
         original_samples = [text.split("TL;DR:")[0] + "TL;DR: " for text in samples]
         original_samples = [
             text + post_summary_dict[text.strip()] for text in original_samples

--- a/examples/summarize_rlhf/trlx_inference_gptj.py
+++ b/examples/summarize_rlhf/trlx_inference_gptj.py
@@ -27,7 +27,7 @@ rw_device = torch.device("cuda:{}".format(1))
 rw_model.to(rw_device)
 
 
-def reward_fn(samples):
+def reward_fn(samples, **kwargs):
     scores_list = []
     batch_size = 2
     for i in range(0, len(samples), batch_size):

--- a/trlx/ray_tune/train_funcs.py
+++ b/trlx/ray_tune/train_funcs.py
@@ -14,7 +14,7 @@ def ppo_sentiments_train(config: dict):
 
     sentiment_fn = pipeline("sentiment-analysis", "lvwerra/distilbert-imdb", device=-1)
 
-    def reward_fn(samples):
+    def reward_fn(samples, **kwargs):
         outputs = sentiment_fn(samples, return_all_scores=True)
         sentiments = [output[1]["score"] for output in outputs]
         return sentiments


### PR DESCRIPTION
* Updates all examples with recent changes to expected `reward_fn` signature.
* Updates the RLHF example `accelerate` config to point to the correct `deepspeed_config_file` when running from the `summarize_rlhf` dir (as suggested in the README). Otherwise, it leads `FileNotFoundError: [Errno 2] No such file or directory: 'ds_config_trlx_gptj_summarize.json'`