### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,50 @@
+
+# Use Nvidia Ubuntu 20 base (includes CUDA if a supported GPU is present)
+# https://hub.docker.com/r/nvidia/cuda
+FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04@sha256:55211df43bf393d3393559d5ab53283d4ebc3943d802b04546a24f3345825bd9
+
+ARG USERNAME
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+RUN groupadd --gid $USER_GID $USERNAME \
+  && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+  && usermod -a -G video user \ 
+  && apt-get update \
+  && apt-get install -y sudo \
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+  && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Install dependencies
+RUN sudo apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+  build-essential \
+  python3.9 \
+  python3.9-dev \
+  python3.9-distutils \
+  python3.9-venv \
+  curl \
+  git
+
+# Install pip (we need the latest version not the standard Ubuntu version, to
+# support modern wheels)
+RUN sudo curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.9 get-pip.py
+
+# Set python aliases
+RUN sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.9 1
+RUN sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+
+# User the new user
+USER $USERNAME
+
+# Install python dev dependencies
+RUN pip install \
+  autopep8 \
+  jedi \
+  mypy \
+  pylance \
+  pytest \
+  toml \
+  yapf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
 RUN groupadd --gid $USER_GID $USERNAME \
   && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-  && usermod -a -G video user \ 
+  && usermod -a -G video user \
   && apt-get update \
   && apt-get install -y sudo \
   && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-
 # Use Nvidia Ubuntu 20 base (includes CUDA if a supported GPU is present)
 # https://hub.docker.com/r/nvidia/cuda
 FROM nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04@sha256:55211df43bf393d3393559d5ab53283d4ebc3943d802b04546a24f3345825bd9

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,3 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/python-3
 {
     "name": "Python 3",
     "build": {
@@ -8,16 +6,12 @@
             "USERNAME": "user"
         }
     },
-    // Configure tool-specific properties.
     "customizations": {
-        // Configure properties specific to VS Code.
         "vscode": {
-            // Set *default* container specific settings.json values on container create.
             "settings": {
                 "python.formatting.autopep8Path": "autopep8",
                 "python.linting.mypyPath": "mypy"
             },
-            // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
                 "davidanson.vscode-markdownlint",
                 "donjayamanne.githistory",
@@ -36,6 +30,5 @@
         }
     },
     "containerUser": "user",
-    // Install any dependencies
     "postCreateCommand": "pip install -e .[dev]"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,20 +13,21 @@
                 "python.linting.mypyPath": "mypy"
             },
             "extensions": [
-                "davidanson.vscode-markdownlint",
-                "donjayamanne.githistory",
-                "donjayamanne.python-extension-pack",
-                "github.vscode-pull-request-github",
-                "ms-python.python",
-                "ms-python.vscode-pylance",
-                "ms-toolsai.jupyter",
-                "ms-vsliveshare.vsliveshare-pack",
-                "njpwerner.autodocstring",
-                "stkb.rewrap",
-                "streetsidesoftware.code-spell-checker",
-                "tushortz.python-extended-snippets",
-                "yzhang.markdown-all-in-one"
-            ]
+				"davidanson.vscode-markdownlint",
+				"donjayamanne.githistory",
+				"donjayamanne.python-extension-pack",
+				"github.vscode-pull-request-github",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-toolsai.jupyter",
+				"ms-vsliveshare.vsliveshare-pack",
+				"njpwerner.autodocstring",
+				"stkb.rewrap",
+				"streetsidesoftware.code-spell-checker",
+				"tushortz.python-extended-snippets",
+				"yzhang.markdown-all-in-one",
+				"elagil.pre-commit-helper"
+			]
         }
     },
     "containerUser": "user",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/python-3
+{
+    "name": "Python 3",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "USERNAME": "user"
+        }
+    },
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "python.formatting.autopep8Path": "autopep8",
+                "python.linting.mypyPath": "mypy"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "davidanson.vscode-markdownlint",
+                "donjayamanne.githistory",
+                "donjayamanne.python-extension-pack",
+                "github.vscode-pull-request-github",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-toolsai.jupyter",
+                "ms-vsliveshare.vsliveshare-pack",
+                "njpwerner.autodocstring",
+                "stkb.rewrap",
+                "streetsidesoftware.code-spell-checker",
+                "tushortz.python-extended-snippets",
+                "yzhang.markdown-all-in-one"
+            ]
+        }
+    },
+    "containerUser": "user",
+    // Install any dependencies
+    "postCreateCommand": "pip install -e .[dev]"
+}


### PR DESCRIPTION
Add [Devcontainer](https://containers.dev/) support so that contributors can setup a working development environment with one click (e.g. with [GitHub Codespaces](https://github.com/features/codespaces) or [VS Code Remote Development Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)).

Includes CUDA support.