### PR TITLE
Fix extraction of `mixed_precision` option for deepspeed

### DIFF
--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -55,10 +55,9 @@ def get_distributed_config(accelerator: Accelerator):
     Return accelerator distributed config
     """
 
-    accelerate_config = accelerator.state
     dist_config = {
-        "mixed_precision": accelerate_config.mixed_precision,
-        "num_gpus": accelerate_config.num_processes,
+        "mixed_precision": accelerator.mixed_precision,
+        "num_gpus": accelerator.num_processes,
     }
 
     if accelerator.state.deepspeed_plugin is not None:


### PR DESCRIPTION
This PR fixes `get_distributed_config` which previously always falsely reported "no" for `mixed_precision` when deepspeed was used

https://wandb.ai/sorry/trlx/runs/7gt7juhb