### PR TITLE
Update Readme to include T5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Transformer Reinforcement Learning X
 
-trlX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo` and `gpt-neox` based) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
+trlX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo`, and `gpt-neox` based, as well as `t5` based models, including `google/t5-v1_1` and `google/flan-t5`) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
 
 You can read more about trlX in our [documentation](https://trlX.readthedocs.io).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Transformer Reinforcement Learning X
 
-trlX allows you to fine-tune 🤗 Hugging Face supported language models (`gpt2`, `gpt-j`, `gpt-neo`, and `gpt-neox` based, as well as `t5` based models, including `google/t5-v1_1` and `google/flan-t5`) up to 20B parameters using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
+trlX allows you to fine-tune 🤗 Hugging Face supported language models of up to 20B parameters (such as `gpt2`, `gpt-j`, and `gpt-neox`, as well as T5 based models, including `google/t5-v1_1` and `google/flan-t5`)  using reinforcement learning via either a provided reward function or reward-labeled dataset. Proximal Policy Optimization ([PPO](https://arxiv.org/pdf/1909.08593.pdf)) and Implicit Language Q-Learning ([ILQL](https://sea-snell.github.io/ILQL_site/)) are implemented.
 
 You can read more about trlX in our [documentation](https://trlX.readthedocs.io).
 


### PR DESCRIPTION
I noticed the readme wasn't updated in PR https://github.com/CarperAI/trlx/pull/145, and doesn't include T5 models. Also thinking this is a last change to close out Issue https://github.com/CarperAI/trlx/issues/132

Not sure if this is important, well worded, too verbose, or if I'm missing other models now supported. Please let me know. Thanks.