### PR TITLE
Support nested updates in `merge`

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -9,8 +9,9 @@ from trlx.data.method_configs import MethodConfig, get_method
 def merge(base: Dict, update: Dict, updated: Set) -> Dict:
     "Recursively updates a nested dictionary with new values"
     for k, v in base.items():
-        if isinstance(v, dict):
-            base[k] = merge(v, update, updated)
+        if k in update and isinstance(v, dict):
+            base[k] = merge(v, update[k], updated)
+            updated.add(k)
         elif k in update:
             base[k] = update[k]
             updated.add(k)


### PR DESCRIPTION
Currently `TRLConfig.update` will fail if given something like `{ "optimizer": { "name": "adam_8bit_bnb" } }"` since it'll check if the `optimizer` key is in `updates`, but `merge` won't add it because the only keys updated are nested. `merge` will check the keys to in every nested dict with the root level keys of the update config, which is problematic when changing an attr that is common across many subconfigs (e.g `"name"`), so this way allows proper nested updates.