### PR TITLE
Fix undefined trackers property

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -418,7 +418,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 rich_table.add_row(*[str(significant(x)) for x in rows[ix]])
 
             if not ray.is_initialized():
-                if "wandb" in self.config.train.trackers:
+                if self.config.train.tracker == "wandb":
                     import wandb
 
                     stats["samples"] = wandb.Table(columns, rows)


### PR DESCRIPTION
This bug was introduced by #209, which changed the `trackers` config property to `tracker` but didn't update this use case.