### PR TITLE
Fix tokenizer missing form config.to_dict()

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -217,9 +217,9 @@ class TRLConfig:
 
     method: MethodConfig
     model: ModelConfig
-    tokenizer: TokenizerConfig
     optimizer: OptimizerConfig
     scheduler: SchedulerConfig
+    tokenizer: TokenizerConfig
     train: TrainConfig
 
     @classmethod
@@ -243,6 +243,7 @@ class TRLConfig:
             "model": self.model.__dict__,
             "optimizer": self.optimizer.__dict__,
             "scheduler": self.scheduler.__dict__,
+            "tokenizer": self.tokenizer.__dict__,
             "train": self.train.__dict__,
         }
 


### PR DESCRIPTION
Fixes the missing property, which was breaking some use cases where hyperparameters are being tuned with Ray

Also orders alphabetically.