### PR TITLE
read tokenizer path from config correctly

### DIFF
--- a/examples/summarize_rlhf/trlx_gptj_text_summarization.py
+++ b/examples/summarize_rlhf/trlx_gptj_text_summarization.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     )
     config = TRLConfig.load_yaml(config_path)
 
-    tokenizer = AutoTokenizer.from_pretrained(config.model.tokenizer_path)
+    tokenizer = AutoTokenizer.from_pretrained(config.tokenizer.tokenizer_path)
     tokenizer.pad_token = tokenizer.eos_token
     tokenizer.padding_side = "left"
     max_length_input = (


### PR DESCRIPTION
In the specific config referenced by summarize_rlhf, it seems like the `model:` block does not have tokenizer_path. There does seem to be one in `tokenizer:` however. 