### PR TITLE
Fix optional tracking in `accelerator.log`

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -112,7 +112,9 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     config=config_dict_flat,
                 )
             elif config.train.tracker is None:
-                self.accelerator.init_trackers(project_name=self.config.train.project_name)
+                self.accelerator.init_trackers(
+                    project_name=self.config.train.project_name
+                )
             else:
                 raise ValueError(
                     f"Only supported trackers are `wandb` and `tensorboard`. Got: `{config.train.tracker}`. "

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -76,11 +76,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
         run_name = "/".join([script_name, model_name, num_gpus]) + f":{branch}"
 
-        if (
-            config.train.tracker is not None
-            and self.accelerator.is_main_process
-            and not ray.is_initialized()
-        ):
+        if self.accelerator.is_main_process and not ray.is_initialized():
             config_dict = self.config.to_dict()
             dist_config = get_distributed_config(self.accelerator)
             config_dict["distributed"] = dist_config
@@ -115,6 +111,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     project_name=self.config.train.project_name,
                     config=config_dict_flat,
                 )
+            elif config.train.tracker is None:
+                self.accelerator.init_trackers(project_name=self.config.train.project_name)
             else:
                 raise ValueError(
                     f"Only supported trackers are `wandb` and `tensorboard`. Got: `{config.train.tracker}`. "


### PR DESCRIPTION
Fixes optional tracking error introduced in #226 in which the null tracker is never handled by `accelerate` (users must init the tracker with a `project_name` and is not simply a no-op)

Example config for `ppo_sentiments.py`:
```yaml
train:
  seq_length: 1024
  epochs: 100
  total_steps: 10000
  batch_size: 128

  checkpoint_interval: 10000
  eval_interval: 100

  pipeline: "PromptPipeline"
  orchestrator: "PPOOrchestrator"
  trainer: "AcceleratePPOTrainer"
  tracker: null  # REMOVE TRACKING

model:
  model_path: "lvwerra/gpt2-imdb"
  num_layers_unfrozen: 2

tokenizer:
  tokenizer_path: "gpt2"
  truncation_side: "right"

optimizer:
  name: "adamw"
  kwargs:
    lr: 1.0e-4
    betas: [0.9, 0.95]
    eps: 1.0e-8
    weight_decay: 1.0e-6

scheduler:
  name: "cosine_annealing"
  kwargs:
    T_max: 10000 # train.total_steps
    eta_min: 1.0e-4

method:
  name: "ppoconfig"
  num_rollouts: 128
  chunk_size: 128
  ppo_epochs: 4
  init_kl_coef: 0.05
  target: 6
  horizon: 10000
  gamma: 1
  lam: 0.95
  cliprange: 0.2
  cliprange_value: 0.2
  vf_coef: 1
  scale_reward: False
  ref_mean: null
  ref_std: null
  cliprange_reward: 10
  gen_kwargs:
    max_new_tokens: 40
    top_k: 0
    top_p: 1.0
    do_sample: True
```