### PR TITLE
fix: change lora_a:float to lora_r:int

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -37,12 +37,14 @@ class ModelConfig:
     :param delta_kwargs: Keyword arguments for instantiating OpenDelta models for delta-tuning.
         Follow the `OpenDelta.AutoDeltaConfig` specification, e.g. for LoRA style tuning, set
         the `delta_type` to `lora` and include the model specific hyper-parameters (e.g. `lora_r`)
-            {"delta_type": "lora", "modified_modules": "all", "lora_r": 5}
+            {"delta_type": "lora", "modified_modules": "all", "lora_r": 8, "lora_alpha": 16, "lora_dropout": 0.0}
         or in YAML format:
             delta_kwargs:
                 delta_type: lora
                 modified_modules: "all"
-                lora_r: 5
+                lora_r: 8
+                lora_alpha: 16
+                lora_dropout: 0.0
         See: https://opendelta.readthedocs.io/en/latest/modules/auto_delta.html#opendelta.auto_delta.AutoDeltaConfig
     :type delta_kwargs: Optional[Dict[str, Any]]
     """

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -36,13 +36,13 @@ class ModelConfig:
 
     :param delta_kwargs: Keyword arguments for instantiating OpenDelta models for delta-tuning.
         Follow the `OpenDelta.AutoDeltaConfig` specification, e.g. for LoRA style tuning, set
-        the `delta_type` to `lora` and include the model specific hyper-parameters (e.g. `lora_a`)
-            {"delta_type": "lora", "modified_modules": "all", "lora_a": 0.5}
+        the `delta_type` to `lora` and include the model specific hyper-parameters (e.g. `lora_r`)
+            {"delta_type": "lora", "modified_modules": "all", "lora_r": 5}
         or in YAML format:
             delta_kwargs:
                 delta_type: lora
                 modified_modules: "all"
-                lora_a: 0.5
+                lora_r: 5
         See: https://opendelta.readthedocs.io/en/latest/modules/auto_delta.html#opendelta.auto_delta.AutoDeltaConfig
     :type delta_kwargs: Optional[Dict[str, Any]]
     """


### PR DESCRIPTION
The example in config.py has lora_a = 0.5 as a parameter. The opendelta docs (and codebase) doesn't have a lora_a parameter, but does have lora_r. Which is the rank of the delta layers(?) and is an int. I am assuming this is intended.

```
config_dict = {
    "delta_type":"lora", 
    "modified_modules":[
        "SelfAttention.q", 
        "SelfAttention.v",
        "SelfAttention.o"
    ], 
    "lora_r":4}
delta_config = AutoDeltaConfig.from_dict(config_dict)
```

Otherwise with lora_a I get the following error:

```
carperAI_trlx_development  | Traceback (most recent call last):
carperAI_trlx_development  |   File "/opt/project/trlx/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py", line 76, in <module>
carperAI_trlx_development  |     trlx.train(
carperAI_trlx_development  |   File "/opt/project/trlx/trlx/trlx.py", line 59, in train
carperAI_trlx_development  |     trainer = get_trainer(config.train.trainer)(
carperAI_trlx_development  |   File "/opt/project/trlx/trlx/trainer/accelerate_ppo_trainer.py", line 26, in __init__
carperAI_trlx_development  |     super().__init__(config, **kwargs)
carperAI_trlx_development  |   File "/opt/project/trlx/trlx/trainer/accelerate_base_trainer.py", line 54, in __init__
carperAI_trlx_development  |     self.model = self.setup_model()
carperAI_trlx_development  |   File "/opt/project/trlx/trlx/trainer/accelerate_base_trainer.py", line 146, in setup_model
carperAI_trlx_development  |     delta_model = delta_model_class(model.base_model, **delta_kwargs)
carperAI_trlx_development  | TypeError: __init__() got an unexpected keyword argument 'lora_a'
carperAI_trlx_development  | ╭───────────────────── Traceback (most recent call last) ──────────────────────╮
carperAI_trlx_development  | │ /opt/project/trlx/examples/summarize_daily_cnn/t5_summarize_daily_cnn.py:76  │
carperAI_trlx_development  | │ in <module>                                                                  │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │   73 │   │   )  # get prompt like trlx's prompt                              │
carperAI_trlx_development  | │   74 │   │   prompt_label[key.strip()] = val_summaries[i]                    │
carperAI_trlx_development  | │   75 │                                                                       │
carperAI_trlx_development  | │ ❱ 76 │   trlx.train(                                                         │
carperAI_trlx_development  | │   77 │   │   config.model.model_path,                                        │
carperAI_trlx_development  | │   78 │   │   reward_fn=reward_fn,                                            │
carperAI_trlx_development  | │   79 │   │   prompts=prompts,                                                │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │ /opt/project/trlx/trlx/trlx.py:59 in train                                   │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │    56 │   │   if model_path:                                                 │
carperAI_trlx_development  | │    57 │   │   │   config.model.model_path = model_path                       │
carperAI_trlx_development  | │    58 │   │                                                                  │
carperAI_trlx_development  | │ ❱  59 │   │   trainer = get_trainer(config.train.trainer)(                   │
carperAI_trlx_development  | │    60 │   │   │   config=config,                                             │
carperAI_trlx_development  | │    61 │   │   │   reward_fn=reward_fn,                                       │
carperAI_trlx_development  | │    62 │   │   │   metric_fn=metric_fn,                                       │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │ /opt/project/trlx/trlx/trainer/accelerate_ppo_trainer.py:26 in __init__      │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │    23 @register_trainer                                                      │
carperAI_trlx_development  | │    24 class AcceleratePPOTrainer(AccelerateRLTrainer):                       │
carperAI_trlx_development  | │    25 │   def __init__(self, config, **kwargs):                              │
carperAI_trlx_development  | │ ❱  26 │   │   super().__init__(config, **kwargs)                             │
carperAI_trlx_development  | │    27 │   │                                                                  │
carperAI_trlx_development  | │    28 │   │   if config.train.rollout_logging_dir is not None:               │
carperAI_trlx_development  | │    29 │   │   │   self.log_rollouts = True                                   │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │ /opt/project/trlx/trlx/trainer/accelerate_base_trainer.py:54 in __init__     │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │    51 │   │   if int(os.environ.get("WORLD_SIZE", 1)) > 1:                   │
carperAI_trlx_development  | │    52 │   │   │   torch.distributed.barrier(device_ids=[int(os.environ.get(" │
carperAI_trlx_development  | │    53 │   │                                                                  │
carperAI_trlx_development  | │ ❱  54 │   │   self.model = self.setup_model()                                │
carperAI_trlx_development  | │    55 │   │   self.opt = self.setup_optimizer()                              │
carperAI_trlx_development  | │    56 │   │   self.scheduler = self.setup_scheduler()                        │
carperAI_trlx_development  | │    57                                                                        │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │ /opt/project/trlx/trlx/trainer/accelerate_base_trainer.py:146 in setup_model │
carperAI_trlx_development  | │                                                                              │
carperAI_trlx_development  | │   143 │   │   │   │   self.config.model.num_layers_unfrozen,                 │
carperAI_trlx_development  | │   144 │   │   │   )                                                          │
carperAI_trlx_development  | │   145 │   │   │   delta_model_class = get_delta_model_class(delta_type)      │
carperAI_trlx_development  | │ ❱ 146 │   │   │   delta_model = delta_model_class(model.base_model, **delta_ │
carperAI_trlx_development  | │   147 │   │   │   delta_model.freeze_module(exclude=["deltas"], set_state_di │
carperAI_trlx_development  | │   148 │   │   │   if self.accelerator.is_main_process:                       │
carperAI_trlx_development  | │   149 │   │   │   │   delta_model.log()                                      │
carperAI_trlx_development  | ╰──────────────────────────────────────────────────────────────────────────────╯
carperAI_trlx_development  | TypeError: __init__() got an unexpected keyword argument 'lora_a'
```