### PR TITLE
Fix deepspeed state saving under `save_best` condition

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -503,16 +503,21 @@ class AccelerateRLTrainer(BaseRLTrainer):
                         results = self.evaluate()
                         stats.update(results)
 
-                        # FIXME: seems to not work with zero and barriers don't seem to help
-                        if (
-                            self.config.train.save_best
-                            and int(os.environ.get("DEEPSPEED_ZERO_STAGE", -1)) == -1
-                        ):
-                            if (
-                                "reward/mean" in stats
-                                and stats["reward/mean"] > best_reward
-                            ):
-                                best_reward = stats["reward/mean"]
+                        # always save checkpoint with the greatest mean reward
+                        if self.config.train.save_best:
+                            if stats.get("reward/mean", -float("inf")) > best_reward:
+                                best_reward = stats.get("reward/mean")
+                                do_save = True
+                            # in case ILQL reports reward estimate as one of its metrics
+                            elif stats.get("metrics/reward", -float("inf")) > best_reward:
+                                best_reward = stats.get("metrics/reward")
+                                do_save = True
+                            else:
+                                do_save = False
+
+                            do_save = torch.tensor(do_save, device=self.accelerator.device)
+                            torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
+                            if do_save:
                                 self.save("best_checkpoint")
 
                         # Report the metrics to Ray Tune.

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -518,7 +518,9 @@ class AccelerateRLTrainer(BaseRLTrainer):
                             do_save = torch.tensor(do_save, device=self.accelerator.device)
                             torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
                             if do_save:
-                                self.save("best_checkpoint")
+                                best_path = f"{self.config.train.checkpoint_dir}/best_checkpoint"
+                                print_rank_0(f"saving the best state so far into {best_path}")
+                                self.save(best_path)
 
                         # Report the metrics to Ray Tune.
                         if ray.is_initialized():

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -509,17 +509,24 @@ class AccelerateRLTrainer(BaseRLTrainer):
                                 best_reward = stats.get("reward/mean")
                                 do_save = True
                             # in case ILQL reports reward estimate as one of its metrics
-                            elif stats.get("metrics/reward", -float("inf")) > best_reward:
+                            elif (
+                                stats.get("metrics/reward", -float("inf")) > best_reward
+                            ):
                                 best_reward = stats.get("metrics/reward")
                                 do_save = True
                             else:
                                 do_save = False
-
-                            do_save = torch.tensor(do_save, device=self.accelerator.device)
-                            torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
+                            do_save = torch.tensor(
+                                do_save, device=self.accelerator.device
+                            )
+                            torch.distributed.all_reduce(
+                                do_save, torch.distributed.ReduceOp.MAX
+                            )
                             if do_save:
                                 best_path = f"{self.config.train.checkpoint_dir}/best_checkpoint"
-                                print_rank_0(f"saving the best state so far into {best_path}")
+                                print_rank_0(
+                                    f"saving the best state so far into {best_path}"
+                                )
                                 self.save(best_path)
 
                         # Report the metrics to Ray Tune.


### PR DESCRIPTION
Fix of https://github.com/CarperAI/trlx/issues/187, complete `stats` dictionary is only available on rank 0 and therefore previously all other processes were on the other side of this if statement https://github.com/CarperAI/trlx/blob/a02f806eb17288456e24c16f1e709d30d958b41b/trlx/trainer/accelerate_base_trainer.py#L511-L514

https://wandb.ai/sorry/trlx/runs/xv5mczq1/logs

(sidenote: these line breaks look dreadful, can we perhaps increase black's --line-length to something like 120?)