### PR TITLE
added colab notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ pip install torch --extra-index-url https://download.pytorch.org/whl/cu116 # for
 pip install -e .
 ```
 
+## Examples
+For more usage see [examples](./examples). You can also try the colab notebooks below:
+| Description      | Link |
+| ----------- | ----------- |
+| Simulacra Example | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vrmCLoHNlKvDVqJjMig-8tKDCfIEoym4?usp=sharing)|
+
+
+
 ## How to Train
 You can train a model using a reward function or a reward-labeled dataset.
 
@@ -55,7 +63,6 @@ accelerate launch examples/simulacra.py
 python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentiments.py
 ```
 
-For more usage see [examples](./examples)
 
 ## Contributing
 


### PR DESCRIPTION
Addressing issue CarperAI/trlx#211, we've wrapped the [simulacra example](./examples/simulacra.py) in a functional colab notebook. This could be reproduced with the other examples.