### PR TITLE
Draft: Fix padding percentage calculation

### DIFF
--- a/trlx/trainer/nn/ppo_models.py
+++ b/trlx/trainer/nn/ppo_models.py
@@ -207,7 +207,7 @@ class PPOConfig(MethodConfig):
             returns=get_tensor_stats(returns, mask, n),
             policy=dict(approx_kl=approx_kl.item(), clipfrac=pg_clipfrac.item()),
             ratio=(ratio * mask).sum() / n,
-            padding_percentage=n / mask.numel(),
+            padding_percentage=n / float(mask.numel()),
         )
 
         return loss, flatten_dict(stats)


### PR DESCRIPTION
Right now in my wandb, padding_percentage is either 1 or 0. This might be because the numpy.numel() fn returns an int and thus casts the result into an int. 