### PR TITLE
Add multi-process logger utility for status monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentimen
 
 trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to the `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output.
 
-To change the log level, you can use one of the direct setters. For example, to set the log level to `WARNING` you can use:
+To change the log level directly, you can use the verbosity setter. For example, to set the log level to `WARNING` use:
 
 ```python
 import trlx
 
-trlx.logging.set_verbosity_warning()
+trlx.logging.set_verbosity(trlx.logging.WARNING)
 ```
 
 This will suppress `INFO` level messages, but still print `WARNING`, `ERROR`, and `CRITICAL` level messages.

--- a/README.md
+++ b/README.md
@@ -65,16 +65,39 @@ python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentimen
 
 ## Logging
 
-trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output. To control the verbosity, you can set the `TRLX_LOG_LEVEL` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels).
+trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to the `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output.
 
-The following example sets the log level to `WARNING` for trlX logging events which will suppress `INFO` level messages, but will still print `WARNING`, `ERROR`, and `CRITICAL` level messages.
+To change the log level, you can use one of the direct setters. For example, to set the log level to `WARNING` you can use:
 
+```python
+import trlx
+
+trlx.logging.set_verbosity_warning()
 ```
-export TRLX_LOG_LEVEL=WARNING
+
+This will suppress `INFO` level messages, but still print `WARNING`, `ERROR`, and `CRITICAL` level messages.
+
+You can also control logging verbosity by setting the `TRLX_VERBOSITY` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels):
+
+* `CRITICAL` (`trlx.logging.CRITICAL`)
+* `ERROR` (`trlx.logging.ERROR`)
+* `WARNING` (`trlx.logging.WARNING`)
+* `INFO` (`trlx.logging.INFO`)
+* `DEBUG` (`trlx.logging.DEBUG`)
+
+```sh
+export TRLX_VERBOSITY=WARNING
 ```
 
-> 💡 Tip: To reduce the amount of logging output, you might find it helpful to change log levels of third-party libraries used by trlX.
-For example, try adding `transformers.logging.set_verbosity_error()` to the top of your trlX scripts to suppress verbose messages from the `transformers` library (see their [logging docs](https://huggingface.co/docs/transformers/main_classes/logging#logging) for more details).
+By default, [`tqdm`](https://tqdm.github.io/docs/tqdm/) progress bars are used to display training progress. You can disable them by calling `trlx.logging.disable_progress_bar()`, otherwise `trlx.logging.enable_progress_bar()` to enable.
+
+Messages can be formatted with greater detail by setting `trlx.logging.enable_explicit_format()`. This will inject call-site information into each log which may be helpful for debugging.
+
+```sh
+[2023-01-01 05:00:00,000] [INFO] [ppo_orchestrator.py:63:make_experience] [RANK 0] Message...
+```
+
+> 💡 Tip: To reduce the amount of logging output, you might find it helpful to change log levels of third-party libraries used by trlX. For example, try adding `transformers.logging.set_verbosity_error()` to the top of your trlX scripts to silence verbose messages from the `transformers` library (see their [logging docs](https://huggingface.co/docs/transformers/main_classes/logging#logging) for more details).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentimen
 
 trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output. To control the verbosity, you can set the `TRLX_LOG_LEVEL` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels).
 
-The following example sets the log level to `WARNING` for trlX logging events.
+The following example sets the log level to `WARNING` for trlX logging events which will suppress `INFO` level messages, but will still print `WARNING`, `ERROR`, and `CRITICAL` level messages.
 
 ```
 export TRLX_LOG_LEVEL=WARNING
 ```
 
-> 💡 Tip: To reduce the amount of logging output, you might find it helpful to change log levels of third-party libraries. For the `transformers` library, try setting `transformers.logging.set_verbosity_error()`.
+> 💡 Tip: To reduce the amount of logging output, you might find it helpful to change log levels of third-party libraries used by trlX.
+For example, try adding `transformers.logging.set_verbosity_error()` to the top of your trlX scripts to suppress verbose messages from the `transformers` library (see their [logging docs](https://huggingface.co/docs/transformers/main_classes/logging#logging) for more details).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentimen
 
 trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output. To control the verbosity, you can set the `TRLX_LOG_LEVEL` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels).
 
-The following example sets the log level to `DEBUG` and prints all messages from trlX to the console.
+The following example sets the log level to `WARNING` for trlX logging events.
 
 ```
-export TRLX_LOG_LEVEL=DEBUG
+export TRLX_LOG_LEVEL=WARNING
 ```
+
+> 💡 Tip: To reduce the amount of logging output, you might find it helpful to change log levels of third-party libraries. For the `transformers` library, try setting `transformers.logging.set_verbosity_error()`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ accelerate launch examples/simulacra.py
 python -m trlx.sweep --config configs/sweeps/ppo_sweep.yml examples/ppo_sentiments.py
 ```
 
+## Logging
+
+trlX uses the standard Python `logging` library to log training information to the console. The default logger is set to `INFO` level, which means that `INFO`, `WARNING`, `ERROR`, and `CRITICAL` level messages will be printed to standard output. To control the verbosity, you can set the `TRLX_LOG_LEVEL` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels).
+
+The following example sets the log level to `DEBUG` and prints all messages from trlX to the console.
+
+```
+export TRLX_LOG_LEVEL=DEBUG
+```
 
 ## Contributing
 

--- a/trlx/__init__.py
+++ b/trlx/__init__.py
@@ -1,1 +1,2 @@
 from .trlx import train
+from .utils import logging

--- a/trlx/orchestrator/offline_orchestrator.py
+++ b/trlx/orchestrator/offline_orchestrator.py
@@ -65,7 +65,7 @@ class OfflineOrchestrator(Orchestrator):
         """
         Tokenizes samples and shapes rewards into proper tensors and then inserts the resulting dataset into the trainer
         """
-        logger.info(f"Collecting rollouts")
+        logger.info("Collecting rollouts")
 
         if self.trainer.tokenizer:
             samples = [tokenize_dialogue(s, self.trainer.tokenizer, max_length) for s in samples]

--- a/trlx/orchestrator/offline_orchestrator.py
+++ b/trlx/orchestrator/offline_orchestrator.py
@@ -6,11 +6,11 @@ import torch
 from rich.console import Console
 from rich.table import Table
 
+import trlx.utils.logging as logging
 from trlx.orchestrator import Orchestrator, register_orchestrator
 from trlx.pipeline.offline_pipeline import ILQLRolloutStorage
-from trlx.utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.get_logger(__name__)
 
 
 def tokenize_dialogue(  # noqa: C901

--- a/trlx/orchestrator/offline_orchestrator.py
+++ b/trlx/orchestrator/offline_orchestrator.py
@@ -1,11 +1,16 @@
+import os
 from typing import List, Union
 
 import numpy as np
 import torch
+from rich.console import Console
+from rich.table import Table
 
 from trlx.orchestrator import Orchestrator, register_orchestrator
 from trlx.pipeline.offline_pipeline import ILQLRolloutStorage
-from trlx.utils import print_rank_0
+from trlx.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 def tokenize_dialogue(  # noqa: C901
@@ -60,6 +65,8 @@ class OfflineOrchestrator(Orchestrator):
         """
         Tokenizes samples and shapes rewards into proper tensors and then inserts the resulting dataset into the trainer
         """
+        logger.info(f"Collecting rollouts")
+
         if self.trainer.tokenizer:
             samples = [tokenize_dialogue(s, self.trainer.tokenizer, max_length) for s in samples]
 
@@ -84,26 +91,29 @@ class OfflineOrchestrator(Orchestrator):
             all_actions_ixs.append(torch.hstack(actions_ixs))
             all_states_ixs.append(states_ixs)
 
-        if self.trainer.tokenizer:
+        if self.trainer.tokenizer and os.environ.get("RANK", "0") == "0":
+            logger.info("Logging sample example")
             prompt = self.trainer.tokenizer.decode(all_input_ids[0][: all_states_ixs[0][1]])
             response = self.trainer.tokenizer.decode(all_input_ids[0][all_states_ixs[0][1] :])
-            print_rank_0("[Sample example]")
-            print_rank_0("Prompt: ", prompt)
-            print_rank_0("Response: ", response)
-            print_rank_0("Reward: ", rewards[0])
+            columns = ["Prompt", "Response", "Reward"]
+            table = Table(*columns, title="Sample Example", show_lines=True)
+            table.add_row(prompt, response, str(rewards[0]))
+            Console().print(table)
 
         sample_lengths = np.array(list(map(len, all_input_ids)))
         output_lengths = np.array(list(map(len, all_actions_ixs)))
         prompt_lengths = sample_lengths - output_lengths
         returns = torch.tensor(rewards, dtype=float)
 
-        def string_stats(name: str, xs: np.array):
-            return f"[Mean {name}] {xs.mean():.2f} ∈ [{min(xs)}, {max(xs)}]"
-
-        print_rank_0(string_stats("prompt length", prompt_lengths))
-        print_rank_0(string_stats("output length", output_lengths))
-        print_rank_0(string_stats("sample length", sample_lengths))
-        print_rank_0(string_stats("return", returns))
+        if os.environ.get("RANK", "0") == "0":
+            logger.info("Logging experience string statistics")
+            columns = ["Prompt Length", "Output Length", "Sample Length"]
+            table = Table(*columns, title="Experience String Stats (mean ∈ \[min, max])", show_lines=True)
+            row = []
+            for lengths in [prompt_lengths, output_lengths, sample_lengths]:
+                row.append(f"{lengths.mean():.2f} ∈ [{min(lengths)}, {max(lengths)}]")
+            table.add_row(*row)
+            Console().print(table)
 
         returns = (returns - returns.mean()) / (returns.std() + 1e-30)
         rewards = [torch.zeros(len(x)) for x in all_actions_ixs]

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -62,9 +62,8 @@ class PPOOrchestrator(Orchestrator):
         logger.info("Collecting rollouts")
         tbar = tqdm(
             total=num_rollouts,
-            disable=not os.environ.get("RANK", 0) == "0",
+            disable=os.environ.get("RANK", 0) != "0",
             position=0,
-            leave=False,
         )
 
         ppo_rl_elements = []
@@ -242,7 +241,7 @@ class PPOOrchestrator(Orchestrator):
             ]
             ppo_rl_elements += new_ppo_rl_elements
             exp_time = clock.tick()
-            tbar.update(n if n < num_rollouts else num_rollouts)
+            tbar.update(min(n, num_rollouts))
         tbar.close()
 
         stats["kl_ctl_value"] = self.trainer.kl_ctl.value

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -14,7 +14,6 @@ from trlx.trainer import BaseRLTrainer
 from trlx.utils import Clock, get_logger
 from trlx.utils.modeling import RunningMoments, logprobs_from_logits
 
-
 logger = get_logger(__name__)
 
 
@@ -60,7 +59,7 @@ class PPOOrchestrator(Orchestrator):
         Takes `num_rollouts` prompts from `pipeline`, samples model and computes the
         KL againts a reference model. It then appends PPOElements to trainer's `store`
         """
-        logger.info(f"Collecting rollouts")
+        logger.info("Collecting rollouts")
         tbar = tqdm(
             total=num_rollouts,
             disable=not os.environ.get("RANK", 0) == "0",
@@ -71,7 +70,7 @@ class PPOOrchestrator(Orchestrator):
         ppo_rl_elements = []
         stats = {}
         clock = Clock()
-        
+
         while len(ppo_rl_elements) < num_rollouts:
             # Get next batch in prompt dataset and refresh if exhausted
             try:

--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -64,6 +64,11 @@ class PPOOrchestrator(Orchestrator):
             total=num_rollouts,
             disable=os.environ.get("RANK", 0) != "0",
             desc=f"[rollout 0 / {num_rollouts}]",
+            # Lower progress bar by 1 if we're in WARNING mode or above to avoid hiding high priority progress
+            # bars (e.g. loss progress in trainers)
+            position=logging.get_verbosity() >= logging.WARNING,
+            # Leave progress bar if we're in INFO mode or lower to avoid spamming in suppressed verbosity levels
+            leave=logging.get_verbosity() < logging.WARNING,
         )
 
         ppo_rl_elements = []

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -283,7 +283,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
     def evaluate(self):  # noqa: C901
         """Samples model on `eval_prompts`, logs stats with `reward_fn` or `metric_fn` if provided"""
-        logger.info("Evaluating the model...")
+        logger.info("Evaluating model")
 
         stats = {}
         table = []
@@ -360,7 +360,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
                 # in online setting, compute the reward for validation
                 if self.reward_fn:
-                    logger.info("Computing rewards...")
+                    logger.info("Computing rewards")
                     rewards = torch.tensor(
                         self.reward_fn(
                             samples=str_samples,
@@ -378,7 +378,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
                 # additionally log any other metrics
                 if self.metric_fn:
-                    logger.info("Computing metrics...")
+                    logger.info("Computing metrics")
                     metric_time = time()
                     metrics = self.metric_fn(
                         samples=str_samples,
@@ -407,7 +407,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 table.append(list(zip(*columns_data)))
 
         # Log and display evaluation metrics
-        logger.info("Summarizing evaluation...")
+        logger.info("Summarizing evaluation")
         if self.accelerator.is_main_process:
             rows = sum(list(map(list, zip(*table))), [])
 
@@ -435,7 +435,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
         """
         Samples batches from `self.store`, updates model and periodically evaluates it on `self.eval_dataloader`
         """
-        logger.info("Starting learning...")
+        logger.info("Starting training")
 
         self.generate_sweep_kwarg = None
         for k, v in self.config.method.gen_kwargs.items():

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -22,9 +22,9 @@ from trlx.utils import (
     filter_non_scalars,
     get_distributed_config,
     get_git_tag,
+    get_logger,
     get_optimizer_class,
     get_scheduler_class,
-    print_rank_0,
     significant,
 )
 from trlx.utils.modeling import (
@@ -34,6 +34,8 @@ from trlx.utils.modeling import (
     get_delta_model_class,
     parse_delta_kwargs,
 )
+
+logger = get_logger(__name__)
 
 
 @register_trainer
@@ -116,6 +118,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
         """
         Returns a model derived from an instance's TRLConfig
         """
+        logger.info(f"Initializing model: {self.config.model.model_path}")
+
         # Retrieves model equipped for ppo, ilql, etc
         model = self.get_arch(self.config)
         if self.config.model.model_arch_type == "seq2seq":
@@ -279,6 +283,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
     def evaluate(self):  # noqa: C901
         """Samples model on `eval_prompts`, logs stats with `reward_fn` or `metric_fn` if provided"""
+        logger.info("Evaluating the model...")
+
         stats = {}
         table = []
 
@@ -288,7 +294,13 @@ class AccelerateRLTrainer(BaseRLTrainer):
         else:
             gen_sweep_values = [None]
 
-        for gen_sweep_value in gen_sweep_values:
+        tbar = tqdm(
+            total=len(self.eval_dataloader) * len(gen_sweep_values),
+            disable=not self.accelerator.is_main_process,
+            position=0,
+        )
+
+        for i_sweep, gen_sweep_value in enumerate(gen_sweep_values):
             # A dedicated suffix for wandb logging
             if gen_sweep_value is not None:
                 sweep_suffix = f"@{gen_sweep_arg}={gen_sweep_value}"
@@ -299,7 +311,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
             all_prompts = []
             prompt_sizes = []
             generate_time = time()
-            for prompts in self.eval_dataloader:
+            for i_prompt, prompts in enumerate(self.eval_dataloader):
                 if self.generate_sweep_kwarg:
                     samples = self.generate_eval(**prompts, **{gen_sweep_arg: gen_sweep_value})
                 else:
@@ -326,6 +338,14 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     torch.tensor(prompts.input_ids.shape[1], device=samples.device).repeat(len(prompts.input_ids))
                 )
 
+                desc = [
+                    f"generation sweep {i_sweep + 1}/{len(gen_sweep_values)}",
+                    f"eval batch {i_prompt + 1}/{len(self.eval_dataloader)}",
+                ]
+                tbar.set_description(f"[{' | '.join(desc)}]")
+                tbar.update()
+            tbar.close()
+
             stats["time/generate"] = time() - generate_time
 
             samples = self.accelerator.gather(torch.vstack(all_samples))
@@ -340,6 +360,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
                 # in online setting, compute the reward for validation
                 if self.reward_fn:
+                    logger.info("Computing rewards...")
                     rewards = torch.tensor(
                         self.reward_fn(
                             samples=str_samples,
@@ -357,6 +378,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
                 # additionally log any other metrics
                 if self.metric_fn:
+                    logger.info("Computing metrics...")
                     metric_time = time()
                     metrics = self.metric_fn(
                         samples=str_samples,
@@ -385,6 +407,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 table.append(list(zip(*columns_data)))
 
         # Log and display evaluation metrics
+        logger.info("Summarizing evaluation...")
         if self.accelerator.is_main_process:
             rows = sum(list(map(list, zip(*table))), [])
 
@@ -395,17 +418,15 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     table_title += f" {k}: {significant(x)}"
 
             rich_table = Table(*columns, title=table_title, show_lines=True)
-
             for ix in range(max(min(3, len(rows)), len(gen_sweep_values))):
                 rich_table.add_row(*[str(significant(x)) for x in rows[ix]])
+            Console().print(rich_table)
 
             if not ray.is_initialized():
                 if self.config.train.tracker == "wandb":
                     import wandb
 
                     stats["samples"] = wandb.Table(columns, rows)
-
-            Console().print(rich_table)
 
         self.nth_evaluation += 1
         return stats
@@ -414,11 +435,13 @@ class AccelerateRLTrainer(BaseRLTrainer):
         """
         Samples batches from `self.store`, updates model and periodically evaluates it on `self.eval_dataloader`
         """
+        logger.info("Starting learning...")
+
         self.generate_sweep_kwarg = None
         for k, v in self.config.method.gen_kwargs.items():
             if isinstance(v, list):
                 if self.generate_sweep_kwarg is not None:
-                    print_rank_0("Only a single sweep is allowed, {k} is going to be set to {v[0]}")
+                    logger.info("Only a single sweep is allowed, {k} is going to be set to {v[0]}")
                     self.generate_kwargs[k] = v[0]
                 else:
                     self.generate_sweep_kwarg = (k, v)
@@ -444,6 +467,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
             initial=self.iter_count,
             total=self.total_steps,
             disable=not self.accelerator.is_local_main_process,
+            leave=True,
         )
 
         best_reward = -float("inf")
@@ -490,7 +514,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                             torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
                             if do_save:
                                 best_path = f"{self.config.train.checkpoint_dir}/best_checkpoint"
-                                print_rank_0(f"saving the best state so far into {best_path}")
+                                logger.info(f"Saving the best state so far into {best_path}")
                                 self.save(best_path)
 
                         # Report the metrics to Ray Tune.
@@ -504,8 +528,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     if not ray.is_initialized():
                         self.accelerator.log(stats, step=self.iter_count)
 
-                    desc = ", ".join(f"{k}: {v:.2f}" for k, v in stats.items() if k.startswith("loss"))
-                    tbar.set_description(desc)
+                    desc = " | ".join(f"{k}: {v:.2f}" for k, v in stats.items() if k.startswith("loss"))
+                    tbar.set_description(f"[{desc}]")
                     tbar.update()
 
                     if self.iter_count >= self.total_steps:
@@ -515,6 +539,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 self.post_backward_callback()
 
             self.post_epoch_callback()
+        tbar.close()
 
     @abstractmethod
     def get_arch(self, config: TRLConfig):

--- a/trlx/utils/__init__.py
+++ b/trlx/utils/__init__.py
@@ -1,14 +1,12 @@
-import logging
 import math
 import os
 import random
 import subprocess
-import sys
 import time
 from dataclasses import is_dataclass
 from enum import Enum
 from numbers import Number
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable
 
 import numpy as np
 import torch
@@ -23,57 +21,6 @@ def print_rank_0(*message):
     """
     if os.environ.get("RANK", "0") == "0":
         print(*message)
-
-
-class MultiProcessAdapter(logging.LoggerAdapter):
-    """A logger adapter for handling multi-process logging"""
-
-    def log(self, level, msg, *args, **kwargs):
-        """
-        Consumes an additional kwarg called `ranks` to determine which processes should log.
-        NOTE: To specify all processes, pass in an empty list `ranks=[]`
-
-        Default: ["0"], i.e. only the main process logs
-        """
-        # By default, silence all non-main processes
-        ranks = kwargs.pop("ranks", ["0"])
-        should_log = os.environ.get("RANK", "0") in ranks or len(ranks) == 0
-        if self.isEnabledFor(level) and should_log:
-            msg, kwargs = self.process(msg, kwargs)
-            self.logger._log(level, msg, args, **kwargs)
-
-    def process(self, msg, kwargs):
-        this_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
-        return f"[RANK {this_rank}] {msg}", kwargs
-
-
-def get_logger(name: str, level: Optional[int] = None) -> MultiProcessAdapter:
-    """
-    Returns a `logging.Logger` for `name` that can handle multiple processes
-
-    Args:
-        name: Name of the logger
-        level: Logging level. Default: `TRLX_LOG_LEVEL` environment variable if
-            present, otherwise `logging.INFO`
-
-    Usage:
-
-    >> logger = get_logger(__name__)
-    >> logger.debug("Check the...", ranks=["0", "1"])  # Only main and rank 1 log
-    """
-    logger = logging.getLogger(name)
-    if level is None:
-        level = os.environ.get("TRLX_LOG_LEVEL", logging.INFO)
-        level = logging.getLevelName(level)
-    logger.setLevel(level)
-    logger.propagate = False
-
-    handler = logging.StreamHandler(stream=sys.stdout)
-    formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] " "[%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
-    handler.setLevel(level)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return MultiProcessAdapter(logger, {})
 
 
 def significant(x: Number, ndigits=2) -> Number:

--- a/trlx/utils/logging.py
+++ b/trlx/utils/logging.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 # Copyright 2023 Optuna, Hugging Face, CarperAI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,15 +17,11 @@ import logging
 import os
 import sys
 import threading
-from logging import DEBUG  
-from logging import ERROR 
-from logging import INFO  
-from logging import WARNING 
+from logging import DEBUG, ERROR, INFO, WARNING
 from typing import Optional
 
 import torch
 from tqdm import auto as tqdm_lib
-
 
 _lock = threading.Lock()
 _default_handler: Optional[logging.Handler] = None
@@ -53,8 +48,7 @@ def _get_default_logging_level():
             return log_levels[env_level_str.lower()]
         else:
             logging.getLogger().warning(
-                f"Unknown option TRLX_VERBOSITY={env_level_str}, "
-                f"has to be one of: { ', '.join(log_levels.keys()) }"
+                f"Unknown option TRLX_VERBOSITY={env_level_str}, " f"has to be one of: { ', '.join(log_levels.keys()) }"
             )
     return _default_log_level
 
@@ -68,7 +62,6 @@ def _get_library_root_logger() -> logging.Logger:
 
 
 def _configure_library_root_logger() -> None:
-
     global _default_handler
 
     with _lock:
@@ -86,7 +79,6 @@ def _configure_library_root_logger() -> None:
 
 
 def _reset_library_root_logger() -> None:
-
     global _default_handler
 
     with _lock:
@@ -131,7 +123,7 @@ def get_logger(name: Optional[str] = None) -> MultiProcessAdapter:
 
     Args:
         name: Name of the logger
-    
+
     Usage:
         >> logger = get_logger(__name__)
         >> logger.debug("Check the...", ranks=["0", "1"])  # Only main and rank 1 log
@@ -264,7 +256,9 @@ def enable_explicit_format() -> None:
     handlers = _get_library_root_logger().handlers
 
     for handler in handlers:
-        formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
+        formatter = logging.Formatter(
+            "[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s"
+        )
         handler.setFormatter(formatter)
 
 

--- a/trlx/utils/logging.py
+++ b/trlx/utils/logging.py
@@ -1,0 +1,358 @@
+# coding=utf-8
+# Copyright 2023 Optuna, Hugging Face, CarperAI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Logging utilities."""
+
+import logging
+import os
+import sys
+import threading
+from logging import DEBUG  
+from logging import ERROR 
+from logging import INFO  
+from logging import WARNING 
+from typing import Optional
+
+import torch
+from tqdm import auto as tqdm_lib
+
+
+_lock = threading.Lock()
+_default_handler: Optional[logging.Handler] = None
+
+log_levels = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_default_log_level = logging.INFO
+
+
+def _get_default_logging_level():
+    """
+    If `TRLX_VERBOSITY` env var is set to one of the valid choices, return that as the new default level. If it is
+    not - fall back to `_default_log_level`
+    """
+    env_level_str = os.getenv("TRLX_VERBOSITY", None)
+    if env_level_str:
+        if env_level_str.lower() in log_levels:
+            return log_levels[env_level_str.lower()]
+        else:
+            logging.getLogger().warning(
+                f"Unknown option TRLX_VERBOSITY={env_level_str}, "
+                f"has to be one of: { ', '.join(log_levels.keys()) }"
+            )
+    return _default_log_level
+
+
+def _get_library_name() -> str:
+    return __name__.split(".")[0]
+
+
+def _get_library_root_logger() -> logging.Logger:
+    return logging.getLogger(_get_library_name())
+
+
+def _configure_library_root_logger() -> None:
+
+    global _default_handler
+
+    with _lock:
+        if _default_handler:
+            # This library has already configured the library root logger.
+            return
+        _default_handler = logging.StreamHandler()  # Set sys.stderr as stream.
+        _default_handler.flush = sys.stderr.flush
+
+        # Apply our default configuration to the library root logger.
+        library_root_logger = _get_library_root_logger()
+        library_root_logger.addHandler(_default_handler)
+        library_root_logger.setLevel(_get_default_logging_level())
+        library_root_logger.propagate = False
+
+
+def _reset_library_root_logger() -> None:
+
+    global _default_handler
+
+    with _lock:
+        if not _default_handler:
+            return
+
+        library_root_logger = _get_library_root_logger()
+        library_root_logger.removeHandler(_default_handler)
+        library_root_logger.setLevel(logging.NOTSET)
+        _default_handler = None
+
+
+def get_log_levels_dict():
+    return log_levels
+
+
+class MultiProcessAdapter(logging.LoggerAdapter):
+    """A logger adapter for handling multi-process logging"""
+
+    def log(self, level, msg, *args, **kwargs):
+        """
+        Consumes an additional kwarg called `ranks` to determine which processes should log.
+        NOTE: To specify all processes, pass in an empty list `ranks=[]`
+
+        Default: ["0"], i.e. only the main process logs
+        """
+        # By default, silence all non-main processes
+        ranks = kwargs.pop("ranks", ["0"])
+        should_log = os.environ.get("RANK", "0") in ranks or len(ranks) == 0
+        if self.isEnabledFor(level) and should_log:
+            msg, kwargs = self.process(msg, kwargs)
+            self.logger._log(level, msg, args, **kwargs)
+
+    def process(self, msg, kwargs):
+        this_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        return f"[RANK {this_rank}] {msg}", kwargs
+
+
+def get_logger(name: Optional[str] = None) -> MultiProcessAdapter:
+    """
+    Returns a `logging.Logger` for `name` that can handle multiple processes
+
+    Args:
+        name: Name of the logger
+    
+    Usage:
+        >> logger = get_logger(__name__)
+        >> logger.debug("Check the...", ranks=["0", "1"])  # Only main and rank 1 log
+    """
+    if name is None:
+        name = _get_library_name()
+    _configure_library_root_logger()
+    logger = logging.getLogger(name)
+    return MultiProcessAdapter(logger, {})
+
+
+def get_verbosity() -> int:
+    """
+    Return the current level for trlx's root logger as an int.
+    Returns:
+        `int`: The logging level.
+    <Tip>
+    trlx has following logging levels:
+    - 50: `trlx.logging.CRITICAL` or `trlx.logging.FATAL`
+    - 40: `trlx.logging.ERROR`
+    - 30: `trlx.logging.WARNING` or `trlx.logging.WARN`
+    - 20: `trlx.logging.INFO`
+    - 10: `trlx.logging.DEBUG`
+    </Tip>"""
+
+    _configure_library_root_logger()
+    return _get_library_root_logger().getEffectiveLevel()
+
+
+def set_verbosity(verbosity: int) -> None:
+    """
+    Set the verbosity level for the trlX's root logger.
+    Args:
+        verbosity (`int`):
+            Logging level, e.g., one of:
+            - `trlx.logging.CRITICAL` or `trlx.logging.FATAL`
+            - `trlx.logging.ERROR`
+            - `trlx.logging.WARNING`
+            - `trlx.logging.INFO`
+            - `trlx.logging.DEBUG`
+    """
+
+    _configure_library_root_logger()
+    _get_library_root_logger().setLevel(verbosity)
+
+
+def set_verbosity_info():
+    """Set the verbosity to the `INFO` level."""
+    return set_verbosity(INFO)
+
+
+def set_verbosity_warning():
+    """Set the verbosity to the `WARNING` level."""
+    return set_verbosity(WARNING)
+
+
+def set_verbosity_debug():
+    """Set the verbosity to the `DEBUG` level."""
+    return set_verbosity(DEBUG)
+
+
+def set_verbosity_error():
+    """Set the verbosity to the `ERROR` level."""
+    return set_verbosity(ERROR)
+
+
+def disable_default_handler() -> None:
+    """Disable the default handler of trlx's root logger."""
+
+    _configure_library_root_logger()
+
+    assert _default_handler is not None
+    _get_library_root_logger().removeHandler(_default_handler)
+
+
+def enable_default_handler() -> None:
+    """Enable the default handler of trlx's root logger."""
+
+    _configure_library_root_logger()
+
+    assert _default_handler is not None
+    _get_library_root_logger().addHandler(_default_handler)
+
+
+def add_handler(handler: logging.Handler) -> None:
+    """Adds a handler to trlx's root logger."""
+
+    _configure_library_root_logger()
+
+    assert handler is not None
+    _get_library_root_logger().addHandler(handler)
+
+
+def remove_handler(handler: logging.Handler) -> None:
+    """Removes given handler from the trlx's root logger."""
+
+    _configure_library_root_logger()
+
+    assert handler is not None and handler not in _get_library_root_logger().handlers
+    _get_library_root_logger().removeHandler(handler)
+
+
+def disable_propagation() -> None:
+    """
+    Disable propagation of the library log outputs. Note that log propagation is disabled by default.
+    """
+
+    _configure_library_root_logger()
+    _get_library_root_logger().propagate = False
+
+
+def enable_propagation() -> None:
+    """
+    Enable propagation of the library log outputs. Please disable the trlx's default handler to prevent
+    double logging if the root logger has been configured.
+    """
+
+    _configure_library_root_logger()
+    _get_library_root_logger().propagate = True
+
+
+def enable_explicit_format() -> None:
+    """
+    Enable explicit formatting for every trlx's logger. The explicit formatter is as follows:
+    ```
+        [ASCTIME] [LEVELNAME] [FILENAME:LINE NUMBER:FUNCNAME] MESSAGE
+    ```
+    All handlers currently bound to the root logger are affected by this method.
+    """
+    handlers = _get_library_root_logger().handlers
+
+    for handler in handlers:
+        formatter = logging.Formatter("[%(asctime)s] [%(levelname)s] [%(filename)s:%(lineno)d:%(funcName)s] %(message)s")
+        handler.setFormatter(formatter)
+
+
+def reset_format() -> None:
+    """
+    Resets the formatting for trlx's loggers.
+    All handlers currently bound to the root logger are affected by this method.
+    """
+    handlers = _get_library_root_logger().handlers
+
+    for handler in handlers:
+        handler.setFormatter(None)
+
+
+def warning_advice(self, *args, **kwargs):
+    """
+    This method is identical to `logger.warning()`, but if env var TRLX_NO_ADVISORY_WARNINGS=1 is set, this
+    warning will not be printed
+    """
+    no_advisory_warnings = os.getenv("TRLX_NO_ADVISORY_WARNINGS", False)
+    if no_advisory_warnings:
+        return
+    self.warning(*args, **kwargs)
+
+
+logging.Logger.warning_advice = warning_advice
+
+
+class EmptyTqdm:
+    """Dummy tqdm which doesn't do anything."""
+
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        self._iterator = args[0] if args else None
+
+    def __iter__(self):
+        return iter(self._iterator)
+
+    def __getattr__(self, _):
+        """Return empty function."""
+
+        def empty_fn(*args, **kwargs):  # pylint: disable=unused-argument
+            return
+
+        return empty_fn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        return
+
+
+_tqdm_active = True
+
+
+class _tqdm_cls:
+    def __call__(self, *args, **kwargs):
+        if _tqdm_active:
+            return tqdm_lib.tqdm(*args, **kwargs)
+        else:
+            return EmptyTqdm(*args, **kwargs)
+
+    def set_lock(self, *args, **kwargs):
+        self._lock = None
+        if _tqdm_active:
+            return tqdm_lib.tqdm.set_lock(*args, **kwargs)
+
+    def get_lock(self):
+        if _tqdm_active:
+            return tqdm_lib.tqdm.get_lock()
+
+
+tqdm = _tqdm_cls()
+
+
+def is_progress_bar_enabled() -> bool:
+    """Return a boolean indicating whether tqdm progress bars are enabled."""
+    global _tqdm_active
+    return bool(_tqdm_active)
+
+
+def enable_progress_bar():
+    """Enable tqdm progress bar."""
+    global _tqdm_active
+    _tqdm_active = True
+
+
+def disable_progress_bar():
+    """Disable tqdm progress bar."""
+    global _tqdm_active
+    _tqdm_active = False

--- a/trlx/utils/logging.py
+++ b/trlx/utils/logging.py
@@ -17,7 +17,14 @@ import logging
 import os
 import sys
 import threading
-from logging import DEBUG, ERROR, INFO, WARNING
+from logging import CRITICAL  # NOQA
+from logging import DEBUG  # NOQA
+from logging import ERROR  # NOQA
+from logging import FATAL  # NOQA
+from logging import INFO  # NOQA
+from logging import NOTSET  # NOQA
+from logging import WARN  # NOQA
+from logging import WARNING  # NOQA
 from typing import Optional
 
 import torch
@@ -147,7 +154,8 @@ def get_verbosity() -> int:
     - 30: `trlx.logging.WARNING` or `trlx.logging.WARN`
     - 20: `trlx.logging.INFO`
     - 10: `trlx.logging.DEBUG`
-    </Tip>"""
+    </Tip>
+    """
 
     _configure_library_root_logger()
     return _get_library_root_logger().getEffectiveLevel()
@@ -155,39 +163,19 @@ def get_verbosity() -> int:
 
 def set_verbosity(verbosity: int) -> None:
     """
-    Set the verbosity level for the trlX's root logger.
+    Set the verbosity level for trlX's root logger.
     Args:
         verbosity (`int`):
             Logging level, e.g., one of:
             - `trlx.logging.CRITICAL` or `trlx.logging.FATAL`
             - `trlx.logging.ERROR`
-            - `trlx.logging.WARNING`
+            - `trlx.logging.WARNING` or `trlx.logging.WARN`
             - `trlx.logging.INFO`
             - `trlx.logging.DEBUG`
     """
 
     _configure_library_root_logger()
     _get_library_root_logger().setLevel(verbosity)
-
-
-def set_verbosity_info():
-    """Set the verbosity to the `INFO` level."""
-    return set_verbosity(INFO)
-
-
-def set_verbosity_warning():
-    """Set the verbosity to the `WARNING` level."""
-    return set_verbosity(WARNING)
-
-
-def set_verbosity_debug():
-    """Set the verbosity to the `DEBUG` level."""
-    return set_verbosity(DEBUG)
-
-
-def set_verbosity_error():
-    """Set the verbosity to the `ERROR` level."""
-    return set_verbosity(ERROR)
 
 
 def disable_default_handler() -> None:


### PR DESCRIPTION
This PR introduces a basic `logging.Logger` utility for status monitoring from the console with multi-process support. By default, the logger is set to the `INFO` level but verbosity can be controlled by setting the `TRLX_LOG_LEVEL` environment variable to one of the standard logging [level names](https://docs.python.org/3/library/logging.html#logging-levels). Check the `README.md` update for more. 

- Replaces prints with logger calls to allow for more control over when and how trlx messages are displayed to users. (`print_rank_0` is kept in utils as a debug tool)

- Adds logger info to indicate evaluation stages such as reward and metric function process during training #239 

- Re-introduces @PhungVanDuy 's  progress bar for evaluating batches of samples #178 
