### PR TITLE
Fix distributed dataloaders & deduplicate eval

### DIFF
--- a/trlx/orchestrator/ppo_orchestrator.py
+++ b/trlx/orchestrator/ppo_orchestrator.py
@@ -35,7 +35,7 @@ class PPOOrchestrator(Orchestrator):
         self.chunk_size = chunk_size
 
         self.pipeline_loader = self.pipeline.create_loader(self.chunk_size, shuffle=True)
-        self.pipeline_loader = self.trainer.accelerator.prepare(self.pipeline_loader)
+        self.pipeline_loader = self.trainer.accelerator.prepare_data_loader(self.pipeline_loader)
         self.pipeline_iterator = iter(self.pipeline_loader)
 
         if not hasattr(self.trainer.model, "frozen_head"):

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -353,9 +353,9 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
             stats["time/generate"] = time() - generate_time
 
-            samples = self.accelerator.gather(torch.vstack(all_samples))
-            prompts = self.accelerator.gather(torch.vstack(all_prompts))
-            prompt_sizes = self.accelerator.gather(torch.hstack(prompt_sizes))
+            samples = self.accelerator.gather_for_metrics(torch.vstack(all_samples))
+            prompts = self.accelerator.gather_for_metrics(torch.vstack(all_prompts))
+            prompt_sizes = self.accelerator.gather_for_metrics(torch.hstack(prompt_sizes))
 
             if self.accelerator.is_main_process:
                 str_samples, str_prompts, str_outputs = self.decode(prompts, samples, prompt_sizes)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -176,10 +176,8 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
     def prepare_learning(self):
         eval_dataloader = self.eval_pipeline.create_loader(self.config.train.batch_size)
-
-        train_dataloader = self.store.create_loader(self.config.train.batch_size, shuffle=True)
-
-        self.train_dataloader, self.eval_dataloader = self.accelerator.prepare(train_dataloader, eval_dataloader)
+        self.eval_dataloader = self.accelerator.prepare_data_loader(eval_dataloader)
+        self.train_dataloader = self.store.create_loader(self.config.train.batch_size, shuffle=True)
 
         self.n_updates_per_batch = self.config.method.ppo_epochs
         self.total_steps = self.config.train.epochs * self.n_updates_per_batch * len(self.train_dataloader)


### PR DESCRIPTION
- Shards `eval_pipeline` (`accelerete.prepare(dataloader)` is a noop with deepspeed) to split evaluation sample between processes
- Trims redundant evaluation samples in case their number is not divisible by the number of processes multiplied by batch size (depends on recent fixes in the newest accelerate release 0.16.0)
- Shards prompt pipeline in `PPOOrchestrator` in the case of deepspeed (previously was sharded only for ddp)
- Unshards training pipeline in the case of ddp (previously only part of rollouts were used on each process during training)

https://wandb.ai/sorry/trlx/reports/Fix-distributed-dataloaders-deduplicate-eval-276---VmlldzozNDgzNDU3

These changes influenced training with both deepspeed & ddp by no more than correcting effective `batch_size` and `num_rollouts`. The number of evaluation samples now is the same as the number of passed `eval_prompts` (this is a fix of https://github.com/CarperAI/trlx/issues/247)

`ppo_sentiments.py @ num_processes=4, batch_size=16, num_rollouts=128, len(eval_prompts)=1024`

main & ddp
len(train_dataloader)=2
len(eval_dataloader)=16

fix & ddp
len(train_dataloader)=8
len(eval_dataloader)=16

main & deepspeed
len(train_dataloader)=8
len(eval_dataloader)=64

fix & deepspeed
len(train_dataloader)=8
len(eval_dataloader)=16