### PR TITLE
Rename remaining `logprobs_from_logits` call

### DIFF
--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -143,7 +143,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
             logits = outputs.logits
             values_pred = outputs.value
-            logprobs = logprobs_from_logits(logits[:, :-1, :], decoder_input_ids[:, 1:])
+            logprobs = logprobs_of_labels(logits[:, :-1, :], decoder_input_ids[:, 1:])
             mask = decoder_input_ids.ne(self.tokenizer.pad_token_id).long().to(self.accelerator.device)
             start = 1
             end = start + response_length


### PR DESCRIPTION
* Removes lingering `logprobs_from_logits` from recent refactoring.
* ~~Adds condition to break out of PPORLElement collection to avoid "overflowing" the storage buffer. Previously, `make_experience` could generate and append more than the `num_rollouts` rollouts to the buffer leading to extended hangs. Reproduce with the following command and config (deepspeed zero-2):~~ 
  
  `accelerate launch examples/ppo_sentiments.py`

 ```yaml
train:
  seq_length: 612
  epochs: 100
  total_steps: 100000
  batch_size: 6

  checkpoint_interval: 10000
  eval_interval: 100
  save_best: False

  pipeline: "PromptPipeline"
  orchestrator: "PPOOrchestrator"
  trainer: "AcceleratePPOTrainer"
  tracker: null

model:
  model_path: "google/flan-t5-small"
  model_arch_type: "seq2seq"
  num_layers_unfrozen: 2

tokenizer:
  tokenizer_path: "google/flan-t5-small"
  truncation_side: "right"

optimizer:
  name: "adamw"
  kwargs:
    lr: 1.0e-5
    betas: [0.9, 0.999]
    eps: 1.0e-8
    weight_decay: 1.0e-6

scheduler:
  name: "cosine_annealing"
  kwargs:
    T_max: 10000
    eta_min: 1.0e-6

method:
  name: "ppoconfig"
  num_rollouts: 512
  chunk_size: 33
  ppo_epochs: 4
  init_kl_coef: 0.05
  target: 6
  horizon: 10000
  gamma: 1
  lam: 0.95
  cliprange: 0.2
  cliprange_value: 0.2
  vf_coef: 1
  scale_reward: False
  ref_mean: null
  ref_std: null
  cliprange_reward: 10
  gen_kwargs:
    max_new_tokens: 40
    top_k: 0
    top_p: 1.0
    do_sample: True
```