### PR TITLE
Remove `pylance` installs from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,6 @@ RUN pip install \
   autopep8 \
   jedi \
   mypy \
-  pylance \
   pytest \
   toml \
   yapf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,6 @@
 				"donjayamanne.python-extension-pack",
 				"github.vscode-pull-request-github",
 				"ms-python.python",
-				"ms-python.vscode-pylance",
 				"ms-toolsai.jupyter",
 				"ms-vsliveshare.vsliveshare-pack",
 				"njpwerner.autodocstring",


### PR DESCRIPTION
* Removes the `pip install pylance` command in the dev Dockerfile. This installs a dependency (https://pypi.org/project/pylance/) unrelated to Microsoft Pylance language server when it doesn't error out.
* Removes `"ms-python.vscode-pylance"` from customizations as it's already included in the installation of `"ms-python.python"` (https://marketplace.visualstudio.com/items?itemName=ms-python.python).

Related Issue: #295

CC @alan-cooney for any suggestions.