### PR TITLE
[feat] Gather experience samples

### DIFF
--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -286,6 +286,42 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
             prompt_tensors = batch.input_ids
             device = samples.device
+
+            prompt_sizes = torch.tensor([prompt_tensors.shape[1]] * len(prompt_tensors), device=device)
+            padded_samples = self.accelerator.pad_across_processes(
+                samples, dim=1, pad_index=self.tokenizer.eos_token_id, pad_first=False
+            )
+            padded_prompts = self.accelerator.pad_across_processes(
+                prompt_tensors, dim=1, pad_index=self.tokenizer.eos_token_id, pad_first=False
+            )
+            gathered_samples = self.accelerator.gather(padded_samples)
+            gathered_prompts = self.accelerator.gather(padded_prompts)
+            gathered_prompt_sizes = self.accelerator.gather(prompt_sizes)
+
+            if torch.distributed.get_rank() == 0:
+                all_str_samples, all_str_prompts, all_str_outputs = self.decode(
+                    gathered_prompts, gathered_samples, gathered_prompt_sizes
+                )
+
+                exp_score_time = time()
+                all_scores = torch.tensor(
+                    self.reward_fn(
+                        samples=all_str_samples,
+                        prompts=all_str_prompts,
+                        outputs=all_str_outputs,
+                    ),
+                    dtype=torch.float,
+                    device=device,
+                )
+                stats["time/exp_score"] = time() - exp_score_time
+
+                all_scores = list(all_scores.reshape(torch.distributed.get_world_size(), -1).unbind())
+            else:
+                all_scores = None
+
+            scores = torch.empty(len(samples), device=device)
+            torch.distributed.scatter(scores, all_scores)
+
             str_samples, str_prompts, str_outputs = self.decode(prompt_tensors, samples)
 
             # Pad the sample outputs
@@ -301,18 +337,6 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
                 for output in outputs
             ]
             sample_outputs = torch.vstack(outputs).to(device)
-
-            exp_score_time = time()
-
-            scores = torch.tensor(
-                self.reward_fn(
-                    samples=str_samples,
-                    prompts=str_prompts,
-                    outputs=str_outputs,
-                ),
-                dtype=torch.float,
-            ).to(device)
-            stats["time/exp_score"] = time() - exp_score_time
 
             # store statistics of the initial rollout as reference
             if self.ref_mean is None:


### PR DESCRIPTION
This PR lets PPO trainer to gather all experience samples on the main rank and to do a single joint reward_fn call per each rollout.

This enables hosting a single reward model on the same machine as the main rank, when previously every process had to had access to the reward model. Also it enables deliberate micro-batching for the reward model, unlike in the case when each process tries to infer reward model (for example deployed on Triton server) with its own small chunk_size number of samples usually bottle-necking whole training.

Main goal here is to give up the current dependency on the Triton server and to enable simple and self-contained 7+1(RM) or 15+1(RM) setups (can finally move to cw)

https://wandb.ai/sorry/trlx/reports/Gather-experience-samples-305---VmlldzozNTMxMzc3

Side-note: every reference remains the same except for sentiments, after some debugging I've noticed that even doing multiple redundant passes of sentiment pipeline on the same data apparently changes rng or otherwise slightly influences the run, as in doing:
```python
scores = torch.tensor(
    self.reward_fn(
        samples=str_samples,
        prompts=str_prompts,
        outputs=str_outputs,
    ),
    dtype=torch.float,
).to(device)

scores = torch.tensor(
    self.reward_fn(
        samples=str_samples,
        prompts=str_prompts,
        outputs=str_outputs,
    ),
    dtype=torch.float,
).to(device)

scores = torch.tensor(
    self.reward_fn(
        samples=str_samples,
        prompts=str_prompts,
        outputs=str_outputs,
    ),
    dtype=torch.float,
).to(device)
```
