### PR TITLE
[fix] Make `gather_for_metrics` usage more strict

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional, Tuple
 
 import ray
 import torch
-import torch.nn.functional as F
 from accelerate import Accelerator  # type: ignore
 from ray.air import session
 from ray.air.checkpoint import Checkpoint
@@ -30,7 +29,6 @@ from trlx.utils.modeling import (
     flatten_dict,
     freeze_bottom_causal_layers,
     freeze_bottom_seq2seq_layers,
-    gather_for_metrics,
     get_delta_model_class,
     parse_delta_kwargs,
 )
@@ -293,9 +291,6 @@ class AccelerateRLTrainer(BaseRLTrainer):
         stats = {}
         table = []
 
-        total_size = len(self.eval_dataloader.dataset)
-        batch_size = self.eval_dataloader.batch_sampler.batch_size
-
         for i_sweep, gen_sweep_value in enumerate(gen_sweep_values):
             # A dedicated suffix for wandb logging
             if gen_sweep_value is not None:
@@ -305,7 +300,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
             all_samples = []
             all_prompts = []
-            prompt_sizes = []
+            all_prompt_sizes = []
             generate_time = time()
             for i_prompt, prompts in enumerate(self.eval_dataloader):
                 if self.generate_sweep_kwarg:
@@ -316,23 +311,17 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 if self.config.model.model_arch_type == "seq2seq":
                     samples = samples[:, 1:]
 
-                all_samples.append(
-                    F.pad(
-                        samples,
-                        (0, self.max_length - samples.shape[1]),
-                        value=self.tokenizer.pad_token_id,
+                prompt_sizes = torch.tensor(prompts.input_ids.shape[1]).repeat(len(prompts.input_ids))
+                prompts, samples, prompt_sizes = self.accelerator.gather_for_metrics(
+                    self.accelerator.pad_across_processes(
+                        [prompts.input_ids, samples, prompt_sizes.to(samples.device)],
+                        dim=1,
+                        pad_index=self.tokenizer.pad_token_id,
                     )
                 )
-                all_prompts.append(
-                    F.pad(
-                        prompts.input_ids,
-                        (0, self.max_length - prompts.input_ids.shape[1]),
-                        value=self.tokenizer.pad_token_id,
-                    ).to(samples.device)
-                )
-                prompt_sizes.append(
-                    torch.tensor(prompts.input_ids.shape[1], device=samples.device).repeat(len(prompts.input_ids))
-                )
+                all_samples.extend(samples.tolist())
+                all_prompts.extend(prompts.tolist())
+                all_prompt_sizes.extend(prompt_sizes.tolist())
 
                 desc = [
                     f"generation sweep {i_sweep + 1}/{len(gen_sweep_values)}",
@@ -344,12 +333,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
             stats["time/generate"] = time() - generate_time
 
-            samples = gather_for_metrics(torch.vstack(all_samples), total_size, batch_size, self.max_length)
-            prompts = gather_for_metrics(torch.vstack(all_prompts), total_size, batch_size, self.max_length)
-            prompt_sizes = gather_for_metrics(torch.hstack(prompt_sizes), total_size, batch_size, 1)
-
             if self.accelerator.is_main_process:
-                str_samples, str_prompts, str_outputs = self.decode(prompts, samples, prompt_sizes)
+                str_samples, str_prompts, str_outputs = self.decode(all_prompts, all_samples, all_prompt_sizes)
 
                 columns = ["prompt", "output"]
                 columns_data = [str_prompts, str_outputs]

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -308,8 +308,10 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 else:
                     samples = self.generate_eval(**prompts)
 
+                # TODO(reciprocated): this should be moved into `decode`
+                # but that needs to be synced with indexing in `make_experience`
                 if self.config.model.model_arch_type == "seq2seq":
-                    samples = samples[:, 1:]
+                    samples = samples[:, 1:].contiguous()
 
                 prompt_sizes = torch.tensor(prompts.input_ids.shape[1]).repeat(len(prompts.input_ids))
                 prompts, samples, prompt_sizes = self.accelerator.gather_for_metrics(

--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 import transformers
+from einops import rearrange
 
 try:
     from opendelta import (
@@ -278,6 +279,24 @@ class RunningMoments:
         self.count = tot_count
 
         return xs_mean, (xs_var * xs_count / (xs_count - 1)).sqrt()
+
+
+def gather_for_metrics(tensor, expected_number, batch_size, length):
+    if not dist.is_initialized():
+        return tensor
+
+    if dist.get_rank() == 0:
+        gather_list = [tensor.clone() for _ in range(dist.get_world_size())]
+    else:
+        gather_list = None
+
+    torch.distributed.gather(tensor, gather_list)
+
+    if dist.get_rank() == 0:
+        tensor = torch.vstack(gather_list).view(dist.get_world_size(), -1, batch_size, length)
+        return rearrange(tensor, "n s b l -> (s n b) l")[:expected_number]
+    else:
+        return None
 
 
 # OpenDelta utilities


### PR DESCRIPTION
This PR makes `accelerate.gather_for_metrics` happen for each batch. Additionally elements of the batch are now padded to batch elements' max_length instead of global seq_length. And they are collected as lists, to avoid one big allocation (possibly bigger than RAM), since they don't have to be tensors afterwards.

https://wandb.ai/sorry/trlx/reports/Make-gather_for_metrics-more-strict-315--VmlldzozNTkyMTUy