### PR TITLE
[feat] Add `batch_size` option for the reward model

### DIFF
--- a/configs/ilql_config.yml
+++ b/configs/ilql_config.yml
@@ -3,6 +3,7 @@ train:
   batch_size: 128
   epochs: 100
   total_steps: 1000
+  reward_model_batch_size: 256
 
   checkpoint_interval: 1000
   eval_interval: 100

--- a/configs/ppo_config.yml
+++ b/configs/ppo_config.yml
@@ -3,6 +3,7 @@ train:
   epochs: 100
   total_steps: 10000
   batch_size: 128
+  reward_model_batch_size: 256
 
   checkpoint_interval: 10000
   eval_interval: 100

--- a/examples/ilql_sentiments.py
+++ b/examples/ilql_sentiments.py
@@ -28,7 +28,7 @@ def main(hparams={}):
         "lvwerra/distilbert-imdb",
         top_k=2,
         truncation=True,
-        batch_size=256,
+        batch_size=config.train.reward_model_batch_size,
         device=0 if int(os.environ.get("LOCAL_RANK", 0)) == 0 else -1,
     )
 

--- a/examples/ppo_sentiments.py
+++ b/examples/ppo_sentiments.py
@@ -37,7 +37,7 @@ def main(hparams={}):
         "lvwerra/distilbert-imdb",
         top_k=2,
         truncation=True,
-        batch_size=256,
+        batch_size=config.train.reward_model_batch_size,
         device=device,
     )
 

--- a/examples/summarize_rlhf/configs/ppo_config_summ_gptj.yml
+++ b/examples/summarize_rlhf/configs/ppo_config_summ_gptj.yml
@@ -3,6 +3,7 @@ train:
   epochs: 50
   total_steps: 100000
   batch_size: 4
+  reward_model_batch_size: 2
 
   checkpoint_interval: 10000
   eval_interval: 200

--- a/examples/summarize_rlhf/trlx_gptj_text_summarization.py
+++ b/examples/summarize_rlhf/trlx_gptj_text_summarization.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     def get_scores(samples: List[str]):
         scores_list = []
-        batch_size = 2
+        batch_size = config.train.reward_model_batch_size
         for i in range(0, len(samples), batch_size):
             sub_samples = samples[i : i + batch_size]
             sub_samples = ["<|startoftext|>" + chosen + "<|endoftext|>" for chosen in sub_samples]

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -140,6 +140,9 @@ class TrainConfig:
     :param batch_size: Batch size for training
     :type batch_size: int
 
+    :param reward_model_batch_size: Batch size for the reward model
+    :type reward_model_batch_size: int
+
     :param tracker: Tracker to use for logging. Default: "wandb"
     :type tracker: str
 
@@ -185,6 +188,7 @@ class TrainConfig:
     seq_length: int
     epochs: int
     batch_size: int
+    reward_model_batch_size: int = 0
 
     checkpoint_interval: int
     eval_interval: int

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -188,7 +188,6 @@ class TrainConfig:
     seq_length: int
     epochs: int
     batch_size: int
-    reward_model_batch_size: int = 0
 
     checkpoint_interval: int
     eval_interval: int
@@ -197,6 +196,7 @@ class TrainConfig:
     trainer: str  # One of the trainers
     trainer_kwargs: Dict[str, Any] = field(default_factory=dict)  # Extra keyword arguments for the trainer
 
+    reward_model_batch_size: int = 0
     project_name: str = "trlx"
     entity_name: Optional[str] = None
     group_name: Optional[str] = None


### PR DESCRIPTION
This PR add's new config option to control `batch_size` used in `reward_fn`. Needed to make custom configs for different setups with different amount of memory available (80GB, 40GB or even cpu offload).

https://api.wandb.ai/links/sorry/g03gp4g7