### PR TITLE
Remove example usage of deprecating `trlx.train` dataset arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ trainer = trlx.train('gpt2', reward_fn=lambda samples, **kwargs: [sample.count('
 #### Using a reward-labeled dataset
 
 ```python
-trainer = trlx.train('EleutherAI/gpt-j-6B', dataset=[('dolphins', 'geese'), (1.0, 100.0)])
+trainer = trlx.train('EleutherAI/gpt-j-6B', samples=['dolphins', 'geese'], rewards=[1.0, 100.0])
 ```
 
 #### Trainers provide a wrapper over their underlying model

--- a/examples/nemo_ilql_sentiments.py
+++ b/examples/nemo_ilql_sentiments.py
@@ -36,7 +36,8 @@ def main(hparams={}):
     imdb = load_dataset("imdb", split="train+test")
 
     trlx.train(
-        dataset=(imdb["text"], imdb["label"]),
+        samples=imdb["text"],
+        rewards=imdb["label"],
         eval_prompts=["I don't know much about Hungarian underground"] * 128,
         metric_fn=metric_fn,
         config=config,

--- a/examples/notebooks/trlx_simulacra.ipynb
+++ b/examples/notebooks/trlx_simulacra.ipynb
@@ -1158,7 +1158,8 @@
       "source": [
         "trlx.train(\n",
         "    \"gpt2\",\n",
-        "    dataset=(prompts, ratings),\n",
+        "    samples=prompts,\n",
+        "    rewards=ratings,\n",
         "    eval_prompts=[\"Hatsune Miku, Red Dress\"] * 64,\n",
         ")"
       ]


### PR DESCRIPTION
Quick fix to remove all `dataset` args to `trlx.train` to avoid promoting deprecating usage.

- If `dataset` is provided, the default behavior is to load the SFT config even though ILQL could be the intended method (see simulacra notebook). 
https://github.com/CarperAI/trlx/blob/165422d1a90eeef2a4a87647477ba5e8703af79b/trlx/trlx.py#L57-L62
