### PR TITLE
Enable infinite PromptPipeline

### DIFF
--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -246,8 +246,8 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
     def add_prompt_pipeline(self, pipeline: PromptPipeline):
         """Add a prompt pipeline dataloader to a trainer instance for the `make_experience` stage"""
         prompt_dataloader = pipeline.create_loader(self.config.method.chunk_size, shuffle=True)
-        self.prompt_dataloader = self.accelerator.prepare_data_loader(prompt_dataloader)
-        self.prompt_iterator = iter(self.prompt_dataloader)
+        prompt_dataloader = self.accelerator.prepare_data_loader(prompt_dataloader)
+        self.prompt_iterator = iter(prompt_dataloader)
 
     def make_experience(self, num_rollouts: int = 1024, iter_count: int = 0):  # noqa:
         """Make experiences
@@ -277,14 +277,8 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
         clock = Clock()
 
         while len(ppo_rl_elements) < num_rollouts:
-            # Get next batch in prompt dataset and refresh if exhausted
-            # TOOD (jon-tow): Make `prompt_dataloader` a cyclic/infinite DataLoader to not require manually
-            # "refreshing" the contents of the `prompt_iterator`
-            try:
-                batch: PromptBatch = next(self.prompt_iterator)
-            except StopIteration:
-                self.prompt_iterator = iter(self.prompt_dataloader)
-                batch = next(self.prompt_iterator)
+            # Get next batch in prompt dataset
+            batch: PromptBatch = next(self.prompt_iterator)
 
             exp_generate_time = time()
 

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -92,7 +92,7 @@ def train(  # noqa: C901
         if eval_prompts is None:
             eval_prompts = prompts[:batch_size]
 
-        pipeline = get_pipeline(config.train.pipeline)(prompts, max_prompt_length, trainer.tokenizer)
+        pipeline = get_pipeline(config.train.pipeline)(prompts, max_prompt_length, trainer.tokenizer, infinite=True)
         trainer.add_prompt_pipeline(pipeline)
 
         if eval_prompts is None:


### PR DESCRIPTION
Add `infinite` flag to `PromptPipeline` to enable cyclic pipeline behavior.
This fixes a TODO in the `accelerate_ppo_trainer.py`.