### PR TITLE
[fix] Drop `<eos>` from ILQL sample's phrases

### DIFF
--- a/examples/randomwalks/ilql_randomwalks.py
+++ b/examples/randomwalks/ilql_randomwalks.py
@@ -34,7 +34,7 @@ def main(hparams):
 
 default_config = TRLConfig(
     train=TrainConfig(
-        seq_length=10,
+        seq_length=11,
         batch_size=100,
         epochs=20,
         total_steps=1000,

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -22,10 +22,9 @@ def tokenize_dialogue(dialogue: Union[str, List[str]], tokenizer, max_length=204
         dialogue = [tokenizer.bos_token, dialogue]
     elif isinstance(dialogue, tuple):
         dialogue = list(dialogue)
-    dialogue[-1] += tokenizer.eos_token
 
     out = []
-    ctx_length = max_length
+    ctx_length = max_length - 1
     if tokenizer.truncation_side == "left":
         for phrase in reversed(dialogue):
             # Manually added BOS and EOS above so we don't want to add special tokens here
@@ -50,8 +49,8 @@ def tokenize_dialogue(dialogue: Union[str, List[str]], tokenizer, max_length=204
             out.append(tokens)
             if ctx_length == 0:
                 break
-    for i in range(len(out)):
-        out[i].append(tokenizer.eos_token_id)
+
+    out[-1].append(tokenizer.eos_token_id)
 
     return out
 


### PR DESCRIPTION
This PR removes `<eos>` token from each sample's prompts & continuations and instead forces the last continuation to end with one, even in case of right truncation. 

https://wandb.ai/sorry/trlx-references/reports/fix-ilql-sample-endings-v-main--VmlldzozNzUyNzAw#ilql_randomwalks/gpt2config/1gpu