### PR TITLE
Add `hypothesis` tests for ILQL

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
 bnb = bitsandbytes
 dev =
     black
+    hypothesis
     isort
     flake8
     pre-commit

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,10 +5,17 @@ import unittest
 
 import torch
 import transformers
+from hypothesis import given
+from hypothesis import strategies as st
 
+from trlx.data.default_configs import default_ilql_config
 from trlx.models.modeling_ilql import (
     AutoModelForCausalLMWithILQLHeads,
     AutoModelForSeq2SeqLMWithILQLHeads,
+    ILQLBatch,
+    ILQLConfig,
+    ILQLHeads,
+    batched_index_select,
 )
 from trlx.models.modeling_ppo import (
     AutoModelForCausalLMWithHydraValueHead,
@@ -419,3 +426,149 @@ class TestAutoModelForSeq2SeqLMWithILQLHeads(unittest.TestCase):
             config.vocab_size = 2
             model = self._auto_model_class.from_config(config, **self._supported_args)
             self.assertEqual(model.base_model.get_output_embeddings().out_features, config.vocab_size)
+
+
+@given(st.integers(1, 100), st.integers(1, 100), st.integers(0, 100), st.integers(1, 100))
+def test_batched_index_select(batch, seq_len, num_idxes, hidden):
+    x = torch.randn(batch, seq_len, hidden)
+    if seq_len > 0:
+        idxs = torch.randint(0, seq_len, (batch, num_idxes))
+    else:
+        idxs = torch.zeros(batch, num_idxes, dtype=torch.long)
+    out = batched_index_select(x, idxs, dim=1)
+
+    # Compute output using for loop
+    out2 = torch.zeros(batch, num_idxes, hidden)
+    for i in range(batch):
+        out2[i] = x[i, idxs[i]]
+
+    assert (out == out2).all()
+
+
+@given(
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.integers(0, 32),
+    st.integers(0, 32),
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.booleans(),
+)
+def test_ilql_heads_indexing(batch_size, seq_len, num_action_idxs, num_state_idxs, hidden_size, vocab_size, two_qs):
+    torch.use_deterministic_algorithms(True)
+
+    heads = ILQLHeads(hidden_size, vocab_size, two_qs, alpha=1.0, dtype=torch.float32)
+
+    # heads(hidden_states, states_ixs, actions_ixs) should
+    # == heads(hidden_states) followed by indexing with states_ixs and actions_ixs
+
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size)
+    states_ixs = torch.randint(0, seq_len, (batch_size, num_state_idxs))
+    actions_ixs = torch.randint(0, seq_len, (batch_size, num_action_idxs))
+
+    qs, target_qs, vs = heads(hidden_states, states_ixs, actions_ixs)
+    qs2, target_qs2, vs2 = heads(hidden_states)
+
+    assert len(qs2) == len(target_qs2) == len(qs)
+
+    qs2 = tuple(batched_index_select(q, actions_ixs, dim=1) for q in qs2)
+    target_qs2 = tuple(batched_index_select(q, actions_ixs, dim=1) for q in target_qs2)
+    vs2 = batched_index_select(vs2, states_ixs, dim=1)
+
+    assert all(torch.allclose(q, q2, atol=1e-06) for q, q2 in zip(qs, qs2))
+    assert all(torch.allclose(q, q2, atol=1e-06) for q, q2 in zip(target_qs, target_qs2))
+    assert torch.allclose(vs, vs2, atol=1e-06)
+
+
+@given(
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.integers(0, 32),
+    st.integers(0, 32),
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.booleans(),
+)
+def test_ilql_heads_output_count_and_shape(
+    batch_size, seq_len, num_action_idxs, num_state_idxs, hidden_size, vocab_size, two_qs
+):
+    heads = ILQLHeads(hidden_size, vocab_size, two_qs, alpha=1.0, dtype=torch.float32)
+
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size)
+    states_ixs = torch.randint(0, seq_len, (batch_size, num_state_idxs))
+    actions_ixs = torch.randint(0, seq_len, (batch_size, num_action_idxs))
+
+    qs, target_qs, vs = heads(hidden_states, states_ixs, actions_ixs)
+
+    assert len(qs) == len(target_qs)
+
+    assert qs[0].shape == (batch_size, num_action_idxs, vocab_size)
+    assert target_qs[0].shape == (batch_size, num_action_idxs, vocab_size)
+    assert vs.shape == (batch_size, num_state_idxs, 1)
+
+    if two_qs:
+        assert len(qs) == 2
+        assert qs[1].shape == (batch_size, num_action_idxs, vocab_size)
+        assert target_qs[1].shape == (batch_size, num_action_idxs, vocab_size)
+    else:
+        assert len(qs) == 1
+
+
+@given(
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.floats(0.0, 1.0),
+    st.booleans(),
+)
+def test_ilql_heads_alpha(hidden_size, vocab_size, alpha, two_qs):
+    heads = ILQLHeads(hidden_size, vocab_size, two_qs, alpha=alpha, dtype=torch.float32)
+
+    for q_head in heads.q_heads:
+        for param in q_head.parameters():
+            param.data.copy_(torch.ones_like(param.data))
+
+    for target_q_head in heads.target_q_heads:
+        for param in target_q_head.parameters():
+            param.data.copy_(torch.zeros_like(param.data))
+
+    heads.sync_target_q_heads()
+
+    for target_q_head in heads.target_q_heads:
+        for param in target_q_head.parameters():
+            assert torch.allclose(param.data, alpha * torch.ones_like(param.data), atol=1e-06)
+
+
+@given(
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.integers(0, 32),
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.integers(1, 32),
+    st.booleans(),
+)
+def test_ilql_loss_doesnt_crash(batch_size, seq_len, num_action_idxs, num_state_idxs, hidden_size, vocab_size, two_qs):
+    ilql_config: ILQLConfig = default_ilql_config().method
+    ilql_config.two_qs = two_qs
+
+    heads = ILQLHeads(hidden_size, vocab_size, two_qs, alpha=1.0, dtype=torch.float32)
+
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size)
+    states_ixs = torch.randint(0, seq_len, (batch_size, num_state_idxs))
+    actions_ixs = torch.randint(0, seq_len, (batch_size, num_action_idxs))
+
+    qs, target_qs, vs = heads(hidden_states, states_ixs, actions_ixs)
+    logits = torch.randn(batch_size, seq_len, vocab_size)
+
+    labels = ILQLBatch(
+        input_ids=torch.randint(0, vocab_size, (batch_size, seq_len + 1)),
+        attention_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+        rewards=torch.randn(batch_size, num_state_idxs - 1, 1),
+        states_ixs=states_ixs,
+        actions_ixs=actions_ixs,
+        dones=torch.randint(0, 2, (batch_size, num_state_idxs, 1), dtype=torch.bool),
+    )
+
+    print(f"{batch_size=}, {seq_len=}, {num_action_idxs=}, {num_state_idxs=}, {hidden_size=}, {vocab_size=}, {two_qs=}")
+    loss_input = logits, (qs, target_qs, vs)
+    loss, stats = ilql_config.loss(loss_input, labels)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,50 +1,113 @@
+from unittest import TestCase
+
 from hypothesis import given
 from hypothesis import strategies as st
 from transformers import AutoTokenizer
 
-from trlx.pipeline.offline_pipeline import tokenize_dialogue
+from trlx.pipeline.offline_pipeline import DialogMessage, tokenize_dialogue
 
 
-@given(st.lists(st.text(), max_size=32))
-def test_tokenize_dialogue_single_turn(response_words):
-    response = " ".join(response_words)
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
-    print(f"{response} -> {tokenized_response}")
-    dialog_tokens = tokenize_dialogue(response, tokenizer)
+class TestTokenizeDialog(TestCase):
+    def setUp(self):
+        self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
-    assert len(dialog_tokens) == 2
-    assert dialog_tokens[0] == [tokenizer.bos_token_id]
-    assert dialog_tokens[1] == tokenized_response + [tokenizer.eos_token_id]
+    @given(st.lists(st.text(), max_size=32))
+    def test_tokenize_dialogue_single_turn(self, response_words):
+        response = " ".join(response_words)  # space seperate to make it multiple tokens
+        tokenized_response = tuple(self.tokenizer(response, add_special_tokens=False).input_ids)
+        tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
+        dialog = tokenize_dialogue(response, self.tokenizer)
 
+        assert len(dialog) == 2
+        user_dm, bot_dm = dialog
 
-@given(st.lists(st.text(), max_size=32), st.integers(min_value=1, max_value=16))
-def test_tokenize_dialogue_single_turn_truncation_right(response_words, max_length):
-    response = " ".join(response_words)
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    tokenizer.truncation_side = "right"
-    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
-    dialog_tokens = tokenize_dialogue(response, tokenizer, max_length=max_length)
+        assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
+        assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
 
-    assert len(dialog_tokens) == 2
-    assert dialog_tokens[0] == [tokenizer.bos_token_id]
-    assert dialog_tokens[1] == tokenized_response[: max_length - 1] + [tokenizer.eos_token_id]
+    @given(st.lists(st.text(), max_size=32), st.integers(min_value=2, max_value=16))
+    def test_tokenize_dialogue_single_turn_truncation_right(self, response_words, max_length):
+        response = " ".join(response_words)  # space seperate to make it multiple tokens
+        self.tokenizer.truncation_side = "right"
+        tokenized_response = tuple(self.tokenizer(response, add_special_tokens=False).input_ids)
+        tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
+        dialog = tokenize_dialogue(response, self.tokenizer, max_length=max_length)
 
-    all_tokens = sum(dialog_tokens, [])
-    assert len(all_tokens) <= max_length
+        assert len(dialog) == 2
+        user_dm, bot_dm = dialog
 
+        assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
+        assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response[: max_length - 1])
 
-@given(st.lists(st.text(), max_size=32), st.integers(min_value=1, max_value=16))
-def test_tokenize_dialogue_single_turn_truncation_left(response_words, max_length):
-    response = " ".join(response_words)  # space seperate to make it multiple tokens
-    tokenizer = AutoTokenizer.from_pretrained("gpt2")
-    tokenizer.truncation_side = "left"
-    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
-    dialog_tokens = tokenize_dialogue(response, tokenizer, max_length=max_length)
+        all_tokens = sum((dm.tokens for dm in dialog), ())
+        assert len(all_tokens) <= max_length
 
-    assert len(dialog_tokens) == 2
-    assert dialog_tokens[0] == [tokenizer.bos_token_id]
-    assert dialog_tokens[1] == tokenized_response[-max_length + 1 :] + [tokenizer.eos_token_id]
+    @given(st.lists(st.text(), max_size=32), st.integers(min_value=2, max_value=16))
+    def test_tokenize_dialogue_single_turn_truncation_left(self, response_words, max_length):
+        response = " ".join(response_words)  # space seperate to make it multiple tokens
+        self.tokenizer.truncation_side = "left"
+        tokenized_response = tuple(self.tokenizer(response, add_special_tokens=False).input_ids)
+        tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
+        dialog = tokenize_dialogue(response, self.tokenizer, max_length=max_length)
 
-    all_tokens = sum(dialog_tokens, [])
-    assert len(all_tokens) <= max_length
+        # if no truncation should have happened, then the user BOS prompt should be present
+        if len(tokenized_response) + 1 <= max_length:
+            assert len(dialog) == 2
+            user_dm, bot_dm = dialog
+
+            assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
+            assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
+        else:
+            assert len(dialog) == 1
+            bot_dm = dialog[0]
+            assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response[-max_length:])
+
+        all_tokens = sum((dm.tokens for dm in dialog), ())
+        assert len(all_tokens) <= max_length
+
+    @given(st.lists(st.tuples(st.text(), st.text()), min_size=1, max_size=32))
+    def test_tokenize_dialogue_multi_turn(self, user_response_pairs):
+        convo = [[" ".join(user_words), " ".join(response_words)] for user_words, response_words in user_response_pairs]
+        flat_convo = sum(convo, [])
+        tokenized_flat_convo = tuple(
+            tuple(self.tokenizer(turn, add_special_tokens=False).input_ids) for turn in flat_convo
+        )
+        tokenized_flat_convo = (*tokenized_flat_convo[:-1], (*tokenized_flat_convo[-1], self.tokenizer.eos_token_id))
+        dialog = tokenize_dialogue(flat_convo, self.tokenizer)
+
+        dm_convo = [DialogMessage(is_output=i % 2 == 1, tokens=tokens) for i, tokens in enumerate(tokenized_flat_convo)]
+        nonempty_dm_convo = [dm for dm in dm_convo if dm.tokens]
+        assert dialog == nonempty_dm_convo
+
+    @given(st.lists(st.tuples(st.text(), st.text()), min_size=1, max_size=32), st.integers(min_value=2, max_value=16))
+    def test_tokenize_dialogue_multi_turn_truncation_right(self, user_response_pairs, max_length):
+        convo = [[" ".join(user_words), " ".join(response_words)] for user_words, response_words in user_response_pairs]
+        flat_convo = sum(convo, [])
+        self.tokenizer.truncation_side = "right"
+        tokenized_flat_convo = tuple(
+            tuple(self.tokenizer(turn, add_special_tokens=False).input_ids) for turn in flat_convo
+        )
+        tokenized_flat_convo = (*tokenized_flat_convo[:-1], (*tokenized_flat_convo[-1], self.tokenizer.eos_token_id))
+        dialog = tokenize_dialogue(flat_convo, self.tokenizer, max_length=max_length)
+
+        all_tokens = sum((dm.tokens for dm in dialog), ())
+        should_be_tokens = sum(tokenized_flat_convo, ())[:max_length]
+        assert all_tokens == should_be_tokens
+        assert len(all_tokens) <= max_length
+
+    @given(st.lists(st.tuples(st.text(), st.text()), min_size=1, max_size=32), st.integers(min_value=2, max_value=16))
+    def test_tokenize_dialogue_multi_turn_truncation_left(self, user_response_pairs, max_length):
+        convo = [[" ".join(user_words), " ".join(response_words)] for user_words, response_words in user_response_pairs]
+        flat_convo = sum(convo, [])
+        self.tokenizer.truncation_side = "left"
+        tokenized_flat_convo = tuple(
+            tuple(self.tokenizer(turn, add_special_tokens=False).input_ids) for turn in flat_convo
+        )
+        tokenized_flat_convo = (*tokenized_flat_convo[:-1], (*tokenized_flat_convo[-1], self.tokenizer.eos_token_id))
+        dialog = tokenize_dialogue(flat_convo, self.tokenizer, max_length=max_length)
+
+        all_tokens = sum((dm.tokens for dm in dialog), ())
+
+        should_be_tokens = sum(tokenized_flat_convo, ())[-max_length:]
+        assert all_tokens == should_be_tokens
+
+        assert len(all_tokens) <= max_length

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,49 @@
+from hypothesis import given
+from hypothesis import strategies as st
+from transformers import AutoTokenizer
+
+from trlx.pipeline.offline_pipeline import tokenize_dialogue
+
+
+@given(st.lists(st.text(), max_size=32))
+def test_tokenize_dialogue_single_turn(response_words):
+    response = " ".join(response_words)
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
+    dialog_tokens = tokenize_dialogue(response, tokenizer)
+
+    assert len(dialog_tokens) == 2
+    assert dialog_tokens[0] == [tokenizer.bos_token_id]
+    assert dialog_tokens[1] == tokenized_response + [tokenizer.eos_token_id]
+
+
+@given(st.lists(st.text(), max_size=32), st.integers(min_value=1, max_value=16))
+def test_tokenize_dialogue_single_turn_truncation_right(response_words, max_length):
+    response = " ".join(response_words)
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer.truncation_side = "right"
+    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
+    dialog_tokens = tokenize_dialogue(response, tokenizer, max_length=max_length)
+
+    assert len(dialog_tokens) == 2
+    assert dialog_tokens[0] == [tokenizer.bos_token_id]
+    assert dialog_tokens[1] == tokenized_response[: max_length - 1] + [tokenizer.eos_token_id]
+
+    all_tokens = sum(dialog_tokens, [])
+    assert len(all_tokens) <= max_length
+
+
+@given(st.lists(st.text(), max_size=32), st.integers(min_value=1, max_value=16))
+def test_tokenize_dialogue_single_turn_truncation_left(response_words, max_length):
+    response = " ".join(response_words)  # space seperate to make it multiple tokens
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer.truncation_side = "left"
+    tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
+    dialog_tokens = tokenize_dialogue(response, tokenizer, max_length=max_length)
+
+    assert len(dialog_tokens) == 2
+    assert dialog_tokens[0] == [tokenizer.bos_token_id]
+    assert dialog_tokens[1] == tokenized_response[-max_length + 1 :] + [tokenizer.eos_token_id]
+
+    all_tokens = sum(dialog_tokens, [])
+    assert len(all_tokens) <= max_length

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -10,6 +10,7 @@ def test_tokenize_dialogue_single_turn(response_words):
     response = " ".join(response_words)
     tokenizer = AutoTokenizer.from_pretrained("gpt2")
     tokenized_response = tokenizer(response, add_special_tokens=False).input_ids
+    print(f"{response} -> {tokenized_response}")
     dialog_tokens = tokenize_dialogue(response, tokenizer)
 
     assert len(dialog_tokens) == 2

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -4,7 +4,7 @@ import torch
 from transformers import AutoTokenizer
 
 from trlx.data.configs import TRLConfig
-from trlx.models.modeling_ppo import CausalLMHydraWithValueHead
+from trlx.models.modeling_ppo import AutoModelForCausalLMWithHydraValueHead
 from trlx.utils.modeling import RunningMoments
 
 
@@ -14,7 +14,9 @@ class TestHydraHead(unittest.TestCase):
     def setUpClass(cls):
         print("Testing Hydra model...")
         config = TRLConfig.load_yaml("configs/test_config.yml")
-        cls.hydra_model = CausalLMHydraWithValueHead(config.model.model_path, config.model.num_layers_unfrozen)
+        cls.hydra_model = AutoModelForCausalLMWithHydraValueHead.from_pretrained(
+            config.model.model_path, num_layers_unfrozen=config.model.num_layers_unfrozen
+        )
 
         tokenizer = AutoTokenizer.from_pretrained(config.tokenizer.tokenizer_path)
         tokenizer.pad_token = tokenizer.eos_token

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -1,0 +1,84 @@
+import unittest
+
+import torch
+from transformers import AutoTokenizer
+
+from trlx.data.configs import TRLConfig
+from trlx.models.modeling_ppo import CausalLMHydraWithValueHead
+from trlx.utils.modeling import RunningMoments
+
+
+# Note tests must start with "test_"
+class TestHydraHead(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print("Testing Hydra model...")
+        config = TRLConfig.load_yaml("configs/test_config.yml")
+        cls.hydra_model = CausalLMHydraWithValueHead(config.model.model_path, config.model.num_layers_unfrozen)
+
+        tokenizer = AutoTokenizer.from_pretrained(config.tokenizer.tokenizer_path)
+        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.padding_side = "left"
+
+        cls.dummy_inputs = tokenizer(
+            "Once upon a time there was a happy goose named Louis. He liked to eat bananas.",
+            truncation=True,
+            padding="max_length",
+            max_length=4,
+            return_tensors="pt",
+        )
+
+    def test_lm_heads(self):
+        with torch.no_grad():
+            unfrozen_outputs = TestHydraHead.hydra_model(
+                **TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True
+            )
+            unfrozen_logits = unfrozen_outputs.logits
+            last_hidden_states = unfrozen_outputs.hidden_states[-1].to(torch.float32)
+            frozen_logits = TestHydraHead.hydra_model.frozen_head.lm_head(last_hidden_states)
+            diff = torch.sum(unfrozen_logits - frozen_logits).item()
+            self.assertEqual(diff, 0)
+
+    def test_frozen_head(self):
+        # Ensure that all parameters of the `hydra_model.frozen_head` are actually frozen
+        for parameter in TestHydraHead.hydra_model.frozen_head.parameters():
+            self.assertTrue(parameter.requires_grad is False)
+
+    def test_forward(self):
+        with torch.no_grad():
+            unfrozen_outputs = TestHydraHead.hydra_model(
+                **TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True
+            )
+            unfrozen_last_hidden_states = unfrozen_outputs.hidden_states[-1]
+            unfrozen_logits = unfrozen_outputs.logits
+
+            frozen_outputs = TestHydraHead.hydra_model.forward_hydra(
+                **TestHydraHead.dummy_inputs, return_dict=True, output_hidden_states=True
+            )
+            frozen_last_hidden_states = frozen_outputs.hidden_states[-1]
+            frozen_logits = frozen_outputs.logits
+
+            hs_diff = torch.sum(unfrozen_last_hidden_states - frozen_last_hidden_states).item()
+            logits_diff = torch.sum(unfrozen_logits - frozen_logits).item()
+            self.assertEqual(hs_diff, 0)
+            self.assertEqual(logits_diff, 0)
+
+
+class TestStatistics(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.m = RunningMoments()
+        cls.a1 = torch.arange(100, dtype=float)
+        cls.a2 = torch.ones(100, dtype=float)
+        cls.a3 = torch.exp(torch.arange(10, dtype=float))
+        cls.a4 = torch.tensor([-10, -1, 0, 1, 10], dtype=float)
+
+    def test_running_moments(self):
+        assert torch.isclose(self.m.update(self.a1)[1], self.a1.std(unbiased=True), atol=1e-6)
+        assert torch.isclose(self.m.update(self.a2)[1], self.a2.std(unbiased=True), atol=1e-6)
+        assert torch.isclose(self.m.update(self.a3)[1], self.a3.std(unbiased=True), atol=1e-6)
+        assert torch.isclose(self.m.update(self.a4)[1], self.a4.std(unbiased=True), atol=1e-6)
+
+        a = torch.hstack((self.a1, self.a2, self.a3, self.a4))
+        assert torch.isclose(self.m.mean, a.mean(), atol=1e-6)
+        assert torch.isclose(self.m.std, a.std(unbiased=True), atol=1e-6)

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -74,10 +74,11 @@ class ILQLConfig(MethodConfig):
         targetQs = [q.gather(-1, actions).squeeze(-1).detach() for q in target_qs]
         targetQ = reduce(torch.minimum, targetQs)
 
+        # The loss_q assumes len(states) == len(rewards) + 1
         # values of current states
-        V = vs[:, :-1].squeeze()
+        V = vs[:, :-1, 0]
         # values of next states
-        Vnext = vs[:, 1:].squeeze() * labels.dones[:, 1:]
+        Vnext = vs[:, 1:, 0] * labels.dones[:, 1:].to(vs.dtype)
         # target to fit Q
         Q_ = labels.rewards + self.gamma * Vnext.detach()
 

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import reduce
 from itertools import chain
+from typing import Optional, Tuple
 
 import deepspeed  # type: ignore
 import numpy as np
@@ -157,11 +158,15 @@ class ILQLHeads(nn.Module):
 
     def forward(
         self,
-        hs: torch.Tensor,
-        states_ixs: torch.Tensor = None,
-        actions_ixs: torch.Tensor = None,
+        hs: TensorType["batch", "seq_len", "hidden"],
+        states_ixs: Optional[TensorType["batch", "states_seq_len"]] = None,
+        actions_ixs: Optional[TensorType["batch", "actions_seq_len"]] = None,
         **kwargs,
-    ):
+    ) -> Tuple[
+        Tuple[TensorType["batch", "actions_seq_len", "hidden"]],
+        Tuple[TensorType["batch", "actions_seq_len", "hidden"]],
+        TensorType["batch", "states_seq_len", "hidden"],
+    ]:
         if states_ixs is not None:
             states_hs = batched_index_select(hs, states_ixs, 1)
             actions_hs = batched_index_select(hs, actions_ixs, 1)

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -37,6 +37,7 @@ def tokenize_dialogue(  # noqa: C901
             tokens = tokenizer(phrase, add_special_tokens=False).input_ids[-ctx_length:]
             ctx_length -= len(tokens)
             out.insert(0, tokens)
+            assert ctx_length >= 0
             if ctx_length == 0:
                 break
 
@@ -53,6 +54,7 @@ def tokenize_dialogue(  # noqa: C901
             tokens = tokenizer(phrase, add_special_tokens=False).input_ids[:ctx_length]
             ctx_length -= len(tokens)
             out.append(tokens)
+            assert ctx_length >= 0
             if ctx_length == 0:
                 break
 

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -3,7 +3,11 @@ from typing import Iterable, List, Union
 import torch
 from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
-from transformers import DataCollatorWithPadding, PreTrainedTokenizer
+from transformers import (
+    DataCollatorWithPadding,
+    PreTrainedTokenizer,
+    PreTrainedTokenizerFast,
+)
 
 from trlx.data.ilql_types import (
     ILQLBatch,
@@ -14,7 +18,9 @@ from trlx.data.ilql_types import (
 from trlx.pipeline import BasePipeline, BaseRolloutStore, register_datapipeline
 
 
-def tokenize_dialogue(dialogue: Union[str, List[str]], tokenizer, max_length=2048) -> List[int]:  # noqa: C901
+def tokenize_dialogue(  # noqa: C901
+    dialogue: Union[str, List[str]], tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], max_length=2048
+) -> List[List[int]]:
     """
     Tokenize sample with the interleaved form of (prompt_1, output_1, prompt_2, output_2...)
     """

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -225,7 +225,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
             table.add_row(*row)
             Console().print(table)
 
-        returns = (returns - returns.mean()) / (returns.std() + 1e-30)
+        returns = (returns - returns.mean()) / (returns.std() + torch.finfo(returns.dtype).eps)
         rewards = [torch.zeros(len(x)) for x in all_actions_ixs]
         for rs, ret in zip(rewards, returns):
             rs[-1] = ret

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -27,6 +27,79 @@ from trlx.utils import to_device
 logger = logging.get_logger(__name__)
 
 
+def make_experience(samples, rewards, tokenizer=None, max_length=2048, verbose=True):  # noqa: C901
+    """
+    Tokenizes samples and shapes rewards into proper tensors and then inserts the resulting dataset into the trainer
+    """
+
+    if verbose:
+        logger.info("Collecting rollouts")
+    if tokenizer is not None:
+        samples = [tokenize_dialogue(s, tokenizer, max_length) for s in samples]
+
+    all_input_ids = []
+    all_actions_ixs = []
+    all_states_ixs = []
+    all_dones = []
+    for sample in samples:
+        length = 0
+        all_input_ids.append(torch.tensor(sum((s.tokens for s in sample), ())))
+        actions_ixs = []
+        for dm in sample:
+            if dm.is_output:
+                actions_ixs.append(torch.arange(length - 1, length + len(dm.tokens) - 1))
+
+            length += len(dm.tokens)
+
+        states_ixs = torch.hstack((*actions_ixs, torch.tensor(length - 1)))
+        all_dones.append(torch.tensor([1] * (len(states_ixs) - 1) + [0], dtype=int))
+        all_actions_ixs.append(torch.hstack(actions_ixs))
+        all_states_ixs.append(states_ixs)
+
+    if tokenizer is not None and os.environ.get("RANK", "0") == "0" and verbose:
+        logger.info("Logging sample example")
+        prompt = tokenizer.decode(all_input_ids[0][: all_states_ixs[0][1]])
+        response = tokenizer.decode(all_input_ids[0][all_states_ixs[0][1] :])
+        columns = ["Prompt", "Response", "Reward"]
+        table = Table(*columns, title="Sample Example", show_lines=True)
+        table.add_row(prompt, response, str(rewards[0]))
+        Console().print(table)
+
+    sample_lengths = np.array(list(map(len, all_input_ids)))
+    output_lengths = np.array(list(map(len, all_actions_ixs)))
+    prompt_lengths = sample_lengths - output_lengths
+    returns = torch.tensor(rewards, dtype=float)
+
+    if os.environ.get("RANK", "0") == "0" and verbose:
+        logger.info("Logging experience string statistics")
+        columns = ["Prompt Length", "Output Length", "Sample Length"]
+        table = Table(*columns, title="Experience String Stats (mean ∈ \[min, max])", show_lines=True)
+        row = []
+        for lengths in [prompt_lengths, output_lengths, sample_lengths]:
+            row.append(f"{lengths.mean():.2f} ∈ [{min(lengths)}, {max(lengths)}]")
+        table.add_row(*row)
+        Console().print(table)
+
+    returns = returns - returns.mean()
+    std_returns = returns.std()
+    if not torch.isnan(std_returns):
+        returns = returns / (std_returns + torch.finfo(returns.dtype).eps)
+    rewards = [torch.zeros(len(x)) for x in all_actions_ixs]
+    for rs, ret in zip(rewards, returns):
+        rs[-1] = ret
+
+    attention_mask = [torch.ones(len(x), dtype=int) for x in all_input_ids]
+
+    return ILQLRolloutStorage(
+        all_input_ids,
+        attention_mask,
+        rewards,
+        all_states_ixs,
+        all_actions_ixs,
+        all_dones,
+    )
+
+
 @register_trainer
 class AccelerateILQLTrainer(AccelerateRLTrainer):
     def __init__(self, config: TRLConfig, **kwargs):
@@ -113,16 +186,14 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         all_states_ixs = []
         all_dones = []
         for sample in samples:
-            all_input_ids.append(torch.tensor(sample[0]))
-            all_output_ids.append(torch.tensor(sample[1]))
-            isoutput = False
+            all_input_ids.append(torch.tensor(sample[0].tokens))
+            all_output_ids.append(torch.tensor(sample[1].tokens))
             actions_ixs = []
             length = 0
             for phrase in sample:
-                if isoutput:
-                    length = len(phrase)
+                if phrase.is_output:
+                    length = len(phrase.tokens)
                     actions_ixs.append(torch.arange(0, length - 1))
-                isoutput = not isoutput
             states_ixs = torch.hstack((*actions_ixs, torch.tensor(length - 1)))
             all_dones.append(torch.tensor([1] * (len(states_ixs) - 1) + [0], dtype=int))
             all_actions_ixs.append(torch.hstack(actions_ixs))
@@ -176,67 +247,4 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         if self.config.model.model_arch_type == "seq2seq":
             return self.make_experience_seq2seq(samples, rewards, max_length)
 
-        logger.info("Collecting rollouts")
-        if self.tokenizer:
-            samples = [tokenize_dialogue(s, self.tokenizer, max_length) for s in samples]
-
-        all_input_ids = []
-        all_actions_ixs = []
-        all_states_ixs = []
-        all_dones = []
-        for sample in samples:
-            length = 0
-            all_input_ids.append(torch.tensor(sum(sample, [])))
-            isoutput = False
-            actions_ixs = []
-            for phrase in sample:
-                if isoutput:
-                    actions_ixs.append(torch.arange(length - 1, length + len(phrase) - 1))
-
-                length += len(phrase)
-                isoutput = not isoutput
-
-            states_ixs = torch.hstack((*actions_ixs, torch.tensor(length - 1)))
-            all_dones.append(torch.tensor([1] * (len(states_ixs) - 1) + [0], dtype=int))
-            all_actions_ixs.append(torch.hstack(actions_ixs))
-            all_states_ixs.append(states_ixs)
-
-        if self.tokenizer and os.environ.get("RANK", "0") == "0":
-            logger.info("Logging sample example")
-            prompt = self.tokenizer.decode(all_input_ids[0][: all_states_ixs[0][1]])
-            response = self.tokenizer.decode(all_input_ids[0][all_states_ixs[0][1] :])
-            columns = ["Prompt", "Response", "Reward"]
-            table = Table(*columns, title="Sample Example", show_lines=True)
-            table.add_row(prompt, response, str(rewards[0]))
-            Console().print(table)
-
-        sample_lengths = np.array(list(map(len, all_input_ids)))
-        output_lengths = np.array(list(map(len, all_actions_ixs)))
-        prompt_lengths = sample_lengths - output_lengths
-        returns = torch.tensor(rewards, dtype=float)
-
-        if os.environ.get("RANK", "0") == "0":
-            logger.info("Logging experience string statistics")
-            columns = ["Prompt Length", "Output Length", "Sample Length"]
-            table = Table(*columns, title="Experience String Stats (mean ∈ \[min, max])", show_lines=True)
-            row = []
-            for lengths in [prompt_lengths, output_lengths, sample_lengths]:
-                row.append(f"{lengths.mean():.2f} ∈ [{min(lengths)}, {max(lengths)}]")
-            table.add_row(*row)
-            Console().print(table)
-
-        returns = (returns - returns.mean()) / (returns.std() + torch.finfo(returns.dtype).eps)
-        rewards = [torch.zeros(len(x)) for x in all_actions_ixs]
-        for rs, ret in zip(rewards, returns):
-            rs[-1] = ret
-
-        attention_mask = [torch.ones(len(x), dtype=int) for x in all_input_ids]
-
-        self.store = ILQLRolloutStorage(
-            all_input_ids,
-            attention_mask,
-            rewards,
-            all_states_ixs,
-            all_actions_ixs,
-            all_dones,
-        )
+        return make_experience(samples, rewards, self.tokenizer, max_length=max_length, verbose=True)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -331,7 +331,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
                 scores = torch.empty(len(samples), device=device)
                 torch.distributed.scatter(scores, all_scores)
             else:
-                scores = torch.tensor(all_scores[0])
+                scores = all_scores[0].clone().detach()
 
             str_samples, str_prompts, str_outputs = self.decode(prompt_tensors, samples)
 

--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -239,6 +239,9 @@ def flatten_dict(
 
 
 def get_tensor_stats(xs: torch.Tensor, mask: torch.Tensor, n: int):
+    if xs.numel() == 0:
+        return dict(mean=0, min=0, max=0, std=0)
+
     mean = (xs * mask).sum() / n
     return dict(
         mean=mean,


### PR DESCRIPTION
Adds more tests for ILQL heads and data preprocessing. Also adds usage of [`hypothesis`](https://hypothesis.readthedocs.io/en/latest/) for generating test cases. 