### PR TITLE
[fix] ILQL `total_steps` calculation when running distributed

### DIFF
--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -96,7 +96,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
 
         self.n_updates_per_batch = 1
-        self.total_steps = self.config.train.epochs * len(train_dataloader)
+        self.total_steps = self.config.train.epochs * len(self.train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
 
     def make_experience_seq2seq(self, samples, rewards, max_length=2048):


### PR DESCRIPTION
Fix of #368, previously `total_steps` were calculated against an unsharded dataloader, wrongly giving n-times bigger estimate of the number of gradient steps in the `tqdm` bar