### PR TITLE
[fix] Fix ILQL head sync under ZeRO3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license = MIT
 [options]
 packages = find:
 install_requires =
-    accelerate>=0.12.0
+    accelerate>=0.16.0
     attrs>=22.1.0
     cattrs>=22.2.0
     datasets

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -305,7 +305,7 @@ class AutoModelForCausalLMWithILQLHeads(PreTrainedModelWrapper):
             attention_mask = torch.hstack((attention_mask, (input_ids != eos_token_id).long()))
             position_ids = (position_ids[:, -1] + 1).view(-1, 1)
 
-            if torch.all(finished):
+            if os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", "0") != "3" and torch.all(finished):
                 break
 
         return samples
@@ -476,7 +476,7 @@ class AutoModelForSeq2SeqLMWithILQLHeads(PreTrainedModelWrapper):
             finished = (next_tokens == eos_token_id).long() | (next_tokens == pad_token_id).long()
             decoder_input_ids = torch.cat([decoder_input_ids, next_tokens], dim=-1)
             samples = decoder_input_ids
-            if torch.all(finished):
+            if os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", "0") != "3" and torch.all(finished):
                 break
 
         return samples

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -180,13 +180,8 @@ class ILQLHeads(nn.Module):
                 target_param.data.copy_((alpha * copy_param.data) + (1.0 - alpha) * target_param.data)
 
     def sync_target_q_heads(self):
-        if os.environ.get("DEEPSPEED_ZERO_STAGE", "0") == "3":
-            params = chain(
-                chain(q_head.parameters() for q_head in self.q_heads),
-                chain(q_head.parameters() for q_head in self.target_q_heads),
-            )
-
-            with deepspeed.zero.GatheredParameters(list(params), modifier_rank=0):
+        if os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", "0") == "3":
+            with deepspeed.zero.GatheredParameters(list(self.parameters()), modifier_rank=0):
                 if deepspeed.comm.get_rank() == 0:
                     self._sync_target_q_heads(self.alpha)
         else:

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -3,7 +3,6 @@ import os
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import reduce
-from itertools import chain
 
 import deepspeed  # type: ignore
 import numpy as np


### PR DESCRIPTION
This PR fixes a bug where ILQL target heads were never being updated on the most recent accelerate & deepspeed versions. Removal of the chain iterator is not just a refactor, it fixed updates on heads from being only temporary and not persistent

https://wandb.ai/sorry/trlx/reports/-fix-Fix-ILQL-head-sync-under-ZeRO3-387---VmlldzozODc1MjI2