### PR TITLE
Add SFT Loss Masking

### DIFF
--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -69,6 +69,32 @@ def tokenize_dialogue(  # noqa: C901
     return truncated
 
 
+class DialogStore(BaseRolloutStore):
+    def __init__(self, dialogs: List[List[DialogMessage]], tokenizer: PreTrainedTokenizer):
+        super().__init__()
+        self.tokenizer = tokenizer
+        attention_masks = [torch.ones(sum(len(m.tokens) for m in d), dtype=torch.bool) for d in dialogs]
+        input_ids = [torch.tensor([t for m in d for t in m.tokens], dtype=torch.long) for d in dialogs]
+        # -100 is the ignore index for CrossEntropyLoss
+        labels = [
+            torch.tensor([t if m.is_output else -100 for m in d for t in m.tokens], dtype=torch.long) for d in dialogs
+        ]
+        self.history = [
+            dict(input_ids=i, attention_mask=a, labels=l) for i, a, l in zip(input_ids, attention_masks, labels)
+        ]
+
+    def create_loader(self, batch_size: int, shuffle=False) -> DataLoader:
+        hf_collate_fn = DataCollatorWithPadding(self.tokenizer)
+
+        def collate_fn(elems: Iterable[dict]):
+            batch = hf_collate_fn(elems)
+            labels = hf_collate_fn([{"input_ids": e["labels"]} for e in elems])["input_ids"]
+            batch["labels"] = labels
+            return batch
+
+        return DataLoader(self, batch_size=batch_size, collate_fn=collate_fn, shuffle=shuffle)
+
+
 @register_datapipeline
 class PromptPipeline(BasePipeline):
     """

--- a/trlx/trainer/accelerate_sft_trainer.py
+++ b/trlx/trainer/accelerate_sft_trainer.py
@@ -4,6 +4,11 @@ from transformers import AutoModelForCausalLM
 
 from trlx.data.configs import TRLConfig
 from trlx.data.method_configs import MethodConfig, register_method
+from trlx.pipeline.offline_pipeline import (
+    DialogStore,
+    PromptPipeline,
+    tokenize_dialogue,
+)
 from trlx.trainer import register_trainer
 from trlx.trainer.accelerate_base_trainer import AccelerateRLTrainer
 
@@ -36,7 +41,13 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
         return AutoModelForCausalLM.from_pretrained(config.model.model_path)
 
     def loss(self, batch):
-        loss = self.model(input_ids=batch.input_ids, attention_mask=batch.attention_mask, labels=batch.input_ids).loss
+        if "labels" in batch:
+            labels = batch.labels.clone()
+        else:
+            labels = batch.input_ids.clone()
+        labels[~batch.attention_mask.bool()] = -100
+
+        loss = self.model(input_ids=batch.input_ids, attention_mask=batch.attention_mask, labels=labels).loss
         stats = {"loss": loss}
 
         return loss, stats
@@ -55,3 +66,10 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
         self.n_updates_per_batch = 1
         self.total_steps = self.config.train.epochs * len(train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
+
+    def make_experience(self, samples, seq_length):
+        if isinstance(samples[0], str):
+            self.store = PromptPipeline(samples, seq_length, self.tokenizer)
+        else:
+            dialogs = [tokenize_dialogue(d, self.tokenizer, seq_length) for d in samples]
+            self.store = DialogStore(dialogs, self.tokenizer)

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -112,8 +112,7 @@ def train(  # noqa: C901
         if rewards is not None:
             trainer.make_experience(samples, rewards, config.train.seq_length)
         else:
-            trainer.store = get_pipeline(config.train.pipeline)(samples, max_prompt_length, trainer.tokenizer)
-
+            trainer.make_experience(samples, config.train.seq_length)
     else:
         raise ValueError("Either `samples` or `reward_fn` should be given for training")
 


### PR DESCRIPTION
This adds loss masking to SFT by setting non-assistant prompt tokens/padding tokens to `-100` label, which is the ignored index for `CrossEntropyLoss`. Will change base to main after the `add-hypothesis` PR is merged.

https://wandb.ai/uwu1/trlx/reports/SFT-Loss-Masking--VmlldzozOTA1Mzg4