### PR TITLE
[fix] Preserve `<eos>` token and in-place it after trimming

### DIFF
--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -445,10 +445,10 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             sample_outputs = sample_outputs.cpu()
             values = values.cpu()[:, :-1]
 
+            # Get the logprobs and values, for tokens that are not padding,
+            # from the start of the prompt up to the <eos> token, while also including the latter
+            # (these are taken from the student model and not the reference model)
             ends = start + attention_mask[:, start:].sum(1) + 1
-
-            # Get the logprobs and values, for tokens that are not padding
-            # or beginning of sequences tokens. These are from the model (not the reference model)
             all_values = [values[ix, start : ends[ix]] for ix in range(n_samples)]
             all_logprobs = [logprobs[ix, start : ends[ix]] for ix in range(n_samples)]
 


### PR DESCRIPTION
This PR fixes #399 and #373 by keeping `<|endoftext|>` token if it was outputted by the model (previously it was treated as if it was one of `stop_sequences`) and replacing trimming after-and-including `stop_sequences` with `<|endoftext|>`, instead of simply discarding them. This lets PPO's `make_experience` never filter any empty outputs, or in the worst case, stuck and timeout.

https://wandb.ai/sorry/trlx-references/reports/fix-preserve-eos-token-v-main--VmlldzozOTE1MDU2