### PR TITLE
[fix] add `device` argument to the call of `modeling_opt._make_causal_mask`

### DIFF
--- a/trlx/models/modeling_ppo.py
+++ b/trlx/models/modeling_ppo.py
@@ -597,8 +597,9 @@ class OPTModelBranch(ModelBranch):
             combined_attention_mask = modeling_opt._make_causal_mask(
                 input_shape,
                 hidden_states.dtype,
+                device=hidden_states.device,
                 past_key_values_length=past_key_values_length,
-            ).to(hidden_states.device)
+            )
 
         if attention_mask is not None:
             expanded_attn_mask = modeling_opt._expand_mask(


### PR DESCRIPTION
This PR fixes a bug in the call of `modeling_opt._make_causal_mask()` in `OPTModelBranch`. This private method requires `device` argument, as found in:
https://github.com/huggingface/transformers/blob/b29fd6971d9cd6ba2a824628effe243f543b8f61/src/transformers/models/opt/modeling_opt.py#L68-L70