### PR TITLE
Add some synchronization to the db download in the simulacra example

### DIFF
--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -1,6 +1,7 @@
 # Optimize prompts by training on prompts-ratings pairings dataset
 # taken from https://github.com/JD-P/simulacra-aesthetic-captions
 
+from accelerate import Accelerator
 import os
 import sqlite3
 import time
@@ -13,9 +14,11 @@ url = "https://raw.githubusercontent.com/JD-P/simulacra-aesthetic-captions/main/
 dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
-    if not os.path.exists(dbpath):
-        print(f"fetching {dbpath}")
-        urlretrieve(url, dbpath)
+    accelerator = Accelerator()
+    with accelerator.local_main_process_first():
+        if os.environ.get('LOCAL_RANK', 0) == 0 and not os.path.exists(dbpath):
+            print(f"fetching {dbpath}")
+            urlretrieve(url, dbpath)
 
     conn = sqlite3.connect(dbpath)
     c = conn.cursor()

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -1,10 +1,11 @@
 # Optimize prompts by training on prompts-ratings pairings dataset
 # taken from https://github.com/JD-P/simulacra-aesthetic-captions
 
-from accelerate import Accelerator
 import os
 import sqlite3
 from urllib.request import urlretrieve
+
+from accelerate import Accelerator
 
 import trlx
 from trlx.data.default_configs import default_ilql_config
@@ -14,7 +15,7 @@ dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
     accelerator = Accelerator()
-    if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
+    if os.environ.get("LOCAL_RANK", "0") == "0" and not os.path.exists(dbpath):
         print(f"fetching {dbpath}")
         urlretrieve(url, dbpath)
     accelerator.wait_for_everyone()

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -12,6 +12,7 @@ url = "https://raw.githubusercontent.com/JD-P/simulacra-aesthetic-captions/main/
 dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
+    print(os.environ)
     if not os.path.exists(dbpath):
         print(f"fetching {dbpath}")
         urlretrieve(url, dbpath)

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -4,7 +4,6 @@
 from accelerate import Accelerator
 import os
 import sqlite3
-import time
 from urllib.request import urlretrieve
 
 import trlx

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -1,8 +1,10 @@
 # Optimize prompts by training on prompts-ratings pairings dataset
 # taken from https://github.com/JD-P/simulacra-aesthetic-captions
 
+from accelerate import Accelerator
 import os
 import sqlite3
+import time
 from urllib.request import urlretrieve
 
 import trlx
@@ -12,10 +14,11 @@ url = "https://raw.githubusercontent.com/JD-P/simulacra-aesthetic-captions/main/
 dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
-    print(os.environ)
-    if not os.path.exists(dbpath):
-        print(f"fetching {dbpath}")
-        urlretrieve(url, dbpath)
+    accelerator = Accelerator()
+    with accelerator.local_main_process_first():
+        if not os.path.exists(dbpath):
+            print(f"fetching {dbpath}")
+            urlretrieve(url, dbpath)
 
     conn = sqlite3.connect(dbpath)
     c = conn.cursor()

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -16,8 +16,6 @@ dbpath = "sac_public_2022_06_29.sqlite"
 if __name__ == "__main__":
     accelerator = Accelerator()
     with accelerator.local_main_process_first():
-        print(os.environ.get('LOCAL_RANK', '0'))
-        print(os.path.exists(dbpath))
         if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
             print(f"fetching {dbpath}")
             urlretrieve(url, dbpath)

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -15,10 +15,9 @@ dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
     accelerator = Accelerator()
-    with accelerator.local_main_process_first():
-        if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
-            print(f"fetching {dbpath}")
-            urlretrieve(url, dbpath)
+    if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
+        print(f"fetching {dbpath}")
+        urlretrieve(url, dbpath)
     accelerator.wait_for_everyone()
 
     conn = sqlite3.connect(dbpath)

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -16,7 +16,7 @@ dbpath = "sac_public_2022_06_29.sqlite"
 if __name__ == "__main__":
     accelerator = Accelerator()
     with accelerator.local_main_process_first():
-        if os.environ.get('LOCAL_RANK', 0) == 0 and not os.path.exists(dbpath):
+        if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
             print(f"fetching {dbpath}")
             urlretrieve(url, dbpath)
 

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -16,6 +16,8 @@ dbpath = "sac_public_2022_06_29.sqlite"
 if __name__ == "__main__":
     accelerator = Accelerator()
     with accelerator.local_main_process_first():
+        print(os.environ.get('LOCAL_RANK', '0'))
+        print(os.path.exists(dbpath))
         if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
             print(f"fetching {dbpath}")
             urlretrieve(url, dbpath)

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -1,7 +1,6 @@
 # Optimize prompts by training on prompts-ratings pairings dataset
 # taken from https://github.com/JD-P/simulacra-aesthetic-captions
 
-from accelerate import Accelerator
 import os
 import sqlite3
 import time
@@ -14,11 +13,9 @@ url = "https://raw.githubusercontent.com/JD-P/simulacra-aesthetic-captions/main/
 dbpath = "sac_public_2022_06_29.sqlite"
 
 if __name__ == "__main__":
-    accelerator = Accelerator()
-    with accelerator.local_main_process_first():
-        if not os.path.exists(dbpath):
-            print(f"fetching {dbpath}")
-            urlretrieve(url, dbpath)
+    if not os.path.exists(dbpath):
+        print(f"fetching {dbpath}")
+        urlretrieve(url, dbpath)
 
     conn = sqlite3.connect(dbpath)
     c = conn.cursor()

--- a/examples/simulacra.py
+++ b/examples/simulacra.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
         if os.environ.get('LOCAL_RANK', '0') == '0' and not os.path.exists(dbpath):
             print(f"fetching {dbpath}")
             urlretrieve(url, dbpath)
+    accelerator.wait_for_everyone()
 
     conn = sqlite3.connect(dbpath)
     c = conn.cursor()


### PR DESCRIPTION
Hi, I'm running the simulacra example just to make sure that our distributed setup works with the TRLX examples, and it seems there is a bit of a race condition with respect to downloading the db, so I added some logic for only local rank 0 to download the db, and a barrier after the download. Let me know if there is another way you prefer to handle this (e.g. we could use sleep for a less reliable solution if you don't want to introduce an accelerate dependency in this example). Thanks!

Screenshot of single and multi node runs
<img width="1079" alt="Screen Shot 2023-03-31 at 11 51 57 AM" src="https://user-images.githubusercontent.com/43149077/229205431-3b9c0701-f361-418f-9d9f-878461c979be.png">
