### PR TITLE
set torch dependency to version 2.0.0 for CUDA in installation instru…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following RL algorithms are currently implemented:
 ```bash
 git clone https://github.com/CarperAI/trlx.git
 cd trlx
-pip install torch --extra-index-url https://download.pytorch.org/whl/cu116 # for cuda
+pip install torch==2.0.0 --extra-index-url https://download.pytorch.org/whl/cu116 # for cuda
 pip install -e .
 ```
 


### PR DESCRIPTION
If there is already a version of Torch installed in your environment, using the same commands won't overwrite it. This can cause some code that uses Torch 2.0 to throw errors. Therefore, it is necessary to explicitly specify the Torch version and also consider upgrading the version of NCCL.
