### PR TITLE
Set pad_token for all tokenizers in tests

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -365,6 +365,7 @@ class TestAutoModelForSeq2SeqLMWithILQLHeads(unittest.TestCase):
     def _create_inputs(self, model_path):
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
         tokenizer.padding_side = "left"
+        tokenizer.pad_token = tokenizer.eos_token
         inputs = tokenizer(self.text, truncation=True, padding="max_length", max_length=4, return_tensors="pt")
         inputs["decoder_input_ids"] = torch.tensor([[tokenizer.pad_token_id]])
         return inputs
@@ -373,7 +374,6 @@ class TestAutoModelForSeq2SeqLMWithILQLHeads(unittest.TestCase):
         for model_path in AUTO_SEQ2SEQ_LM_PATHS:
             model = self._auto_model_class.from_pretrained(model_path, **self._supported_args)
             inputs = self._create_inputs(model_path)
-            print(inputs)
             # Ensure that the `forward` method doesn't throw an error on generic inputs
             try:
                 model(**inputs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,9 +45,10 @@ class TestAutoModelForCausalLMWithValueHead(unittest.TestCase):
 
     def _create_inputs(self, model_path):
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
-        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         tokenizer.padding_side = "left"
-        return tokenizer(self.text, truncation=True, padding="max_length", max_length=4, return_tensors="pt")
+        tokenized = tokenizer(self.text, truncation=True, padding="max_length", max_length=4, return_tensors="pt")
+        return dict(input_ids=tokenized.input_ids, attention_mask=tokenized.attention_mask)
 
     def test_forward(self):
         for model_path in AUTO_CAUSAL_LM_PATHS:
@@ -290,7 +291,7 @@ class TestAutoModelForCausalLMWithILQLHeads(unittest.TestCase):
 
     def _create_inputs(self, model_path):
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
-        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         tokenizer.padding_side = "left"
         return tokenizer(self.text, truncation=True, padding="max_length", max_length=4, return_tensors="pt")
 
@@ -365,7 +366,7 @@ class TestAutoModelForSeq2SeqLMWithILQLHeads(unittest.TestCase):
     def _create_inputs(self, model_path):
         tokenizer = transformers.AutoTokenizer.from_pretrained(model_path)
         tokenizer.padding_side = "left"
-        tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.add_special_tokens({"pad_token": "[PAD]"})
         inputs = tokenizer(self.text, truncation=True, padding="max_length", max_length=4, return_tensors="pt")
         inputs["decoder_input_ids"] = torch.tensor([[tokenizer.pad_token_id]])
         return inputs


### PR DESCRIPTION
Tests were breaking due to one of the `self._create_inputs` in the model tests not doing this