### PR TITLE
Convert tensors in the stats dict into scalars

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -388,7 +388,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     stats["time/metric"] = time() - metric_time
 
                     mean_metrics = {
-                        f"metrics/{k}{sweep_suffix}": torch.as_tensor(xs).mean(-1) for k, xs in metrics.items()
+                        f"metrics/{k}{sweep_suffix}": torch.as_tensor(xs).mean(-1).item() for k, xs in metrics.items()
                     }
 
                     stats.update(mean_metrics)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -351,10 +351,10 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             if self.ref_mean is None:
                 self.ref_mean, self.ref_std = scores.mean(), scores.std()
             all_scores_mean, all_scores_std = self.running_moments.update(scores)
-            stats["exp_scores/mean"] = all_scores_mean
-            stats["exp_scores/std"] = all_scores_std
-            stats["exp_scores/running_mean"] = self.running_moments.mean
-            stats["exp_scores/running_std"] = self.running_moments.std
+            stats["exp_scores/mean"] = all_scores_mean.item()
+            stats["exp_scores/std"] = all_scores_std.item()
+            stats["exp_scores/running_mean"] = self.running_moments.mean.item()
+            stats["exp_scores/running_std"] = self.running_moments.std.item()
 
             if self.config.method.scale_reward == "running":
                 scores /= self.running_moments.std
@@ -479,7 +479,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
         if torch.distributed.is_initialized():
             torch.distributed.all_reduce(self.mean_kl, torch.distributed.ReduceOp.AVG)
 
-        stats["policy/sqrt_kl"] = torch.sqrt(self.mean_kl)
+        stats["policy/sqrt_kl"] = torch.sqrt(self.mean_kl).item()
         stats["kl_ctl_value"] = self.kl_ctl.value
         stats["time/exp"] = exp_time
 

--- a/trlx/trainer/accelerate_sft_trainer.py
+++ b/trlx/trainer/accelerate_sft_trainer.py
@@ -48,7 +48,7 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
         labels[~batch.attention_mask.bool()] = -100
 
         loss = self.model(input_ids=batch.input_ids, attention_mask=batch.attention_mask, labels=labels).loss
-        stats = {"loss": loss}
+        stats = {"loss": loss.item()}
 
         return loss, stats
 


### PR DESCRIPTION
The values of some items in the stats dictionary are tensors in the current code, and it prevents a tensorboard accelerate tracker from logging them.
This PR converts those tensors into scalars via `.item()` and makes the tensorboard tracker behave as expected.