### PR TITLE
Ensure trailing EOS token is added correctly for shorter generated outputs

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -219,9 +219,11 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
             # Recover the last <eos> if it was present in the original sample
             # or add one if it was trimmed with `self.stop_sequences`.
-            # Only in cases when a generation ended due to `max_new_tokens` exhaustion,
-            # <eos> token would not be present in the original sample
-            if append_eos_token and (trimmed or self.tokenizer.eos_token_id in sample):
+            # When a generation ended due to `max_new_tokens` exhaustion,
+            # only then <pad> or <eos> token would not be present in the original sample at the end
+            if append_eos_token and (
+                trimmed or sample[-1] == self.tokenizer.eos_token_id or sample[-1] == self.tokenizer.pad_token_id
+            ):
                 str_output += self.tokenizer.eos_token
 
             str_prompts.append(str_prompt)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -221,7 +221,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
             # or add one if it was trimmed with `self.stop_sequences`.
             # Only in cases when a generation ended due to `max_new_tokens` exhaustion,
             # <eos> token would not be present in the original sample
-            if append_eos_token and (trimmed or sample[-1] == self.tokenizer.eos_token_id):
+            if append_eos_token and (trimmed or self.tokenizer.eos_token_id in sample):
                 str_output += self.tokenizer.eos_token
 
             str_prompts.append(str_prompt)


### PR DESCRIPTION
Ensure trailing EOS token is added also when the generated output contains trailing padding as is often the case when doing batch generation. When doing batched generations, some generated samples will end earlier than other samples. The samples that ended earlier will (in the case of T5/MT5) contain trailing `<pad>` tokens. The `sample[-1]` test to check if the last token of the sample is `<eos>` only works when the `<eos>` token comes last, which is only true for the longest of the generated samples.