### PR TITLE
Pad prompts to the right in T5 examples and add EOS token to seq2seq prompts

### DIFF
--- a/examples/ilql_sentiments_t5.py
+++ b/examples/ilql_sentiments_t5.py
@@ -41,6 +41,7 @@ default_config = TRLConfig(
     ),
     tokenizer=TokenizerConfig(
         tokenizer_path="lvwerra/t5-imdb",
+        padding_side="right",
         truncation_side="right",
     ),
     optimizer=OptimizerConfig(

--- a/examples/ppo_sentiments_t5.py
+++ b/examples/ppo_sentiments_t5.py
@@ -43,6 +43,7 @@ default_config = TRLConfig(
     ),
     tokenizer=TokenizerConfig(
         tokenizer_path="lvwerra/t5-imdb",
+        padding_side="right",
         truncation_side="right",
     ),
     optimizer=OptimizerConfig(

--- a/examples/ppo_translation_t5.py
+++ b/examples/ppo_translation_t5.py
@@ -54,6 +54,7 @@ default_config = TRLConfig(
     ),
     tokenizer=TokenizerConfig(
         tokenizer_path="t5-large",
+        padding_side="right",
         truncation_side="right",
     ),
     optimizer=OptimizerConfig(

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -109,7 +109,8 @@ class PromptPipeline(BasePipeline):
         max_prompt_length (`int`): max length of the prompt, if exceeded the prompt will be truncated according to
             tokenizer's truncation setting.
         tokenizer (`transformers.PreTrainedTokenizer`): a tokenizer to tokenize prompts with.
-        add_special_tokens (`bool`): Whether to encode prompts with tokenizer's special tokens (passed directly into `tokenizer.encode`)
+        add_special_tokens (`bool`): whether to encode prompts with tokenizer's special tokens (passed directly
+            into `tokenizer.encode`)
     """
 
     def __init__(

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -112,7 +112,7 @@ class PromptPipeline(BasePipeline):
     """
 
     def __init__(
-        self, prompts: Union[Dict[str, Any], List[str]], max_prompt_length: int, tokenizer: PreTrainedTokenizer
+        self, prompts: Union[Dict[str, Any], List[str]], max_prompt_length: int, tokenizer: PreTrainedTokenizer, add_special_tokens: bool
     ):
         super().__init__()
 
@@ -123,7 +123,7 @@ class PromptPipeline(BasePipeline):
             metadata = [{}] * len(prompts)
 
         model_inputs = tokenizer(
-            prompts, truncation=True, padding=False, max_length=max_prompt_length, add_special_tokens=False
+            prompts, truncation=True, padding=False, max_length=max_prompt_length, add_special_tokens=add_special_tokens
         )
 
         prompts_tokens = model_inputs["input_ids"]

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -109,6 +109,7 @@ class PromptPipeline(BasePipeline):
         max_prompt_length (`int`): max length of the prompt, if exceeded the prompt will be truncated according to
             tokenizer's truncation setting.
         tokenizer (`transformers.PreTrainedTokenizer`): a tokenizer to tokenize prompts with.
+        add_special_tokens (`bool`): Whether to encode prompts with tokenizer's special tokens (passed directly into `tokenizer.encode`)
     """
 
     def __init__(
@@ -116,7 +117,7 @@ class PromptPipeline(BasePipeline):
         prompts: Union[Dict[str, Any], List[str]],
         max_prompt_length: int,
         tokenizer: PreTrainedTokenizer,
-        add_special_tokens: bool,
+        add_special_tokens: bool = False,
     ):
         super().__init__()
 

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -112,7 +112,11 @@ class PromptPipeline(BasePipeline):
     """
 
     def __init__(
-        self, prompts: Union[Dict[str, Any], List[str]], max_prompt_length: int, tokenizer: PreTrainedTokenizer, add_special_tokens: bool
+        self,
+        prompts: Union[Dict[str, Any], List[str]],
+        max_prompt_length: int,
+        tokenizer: PreTrainedTokenizer,
+        add_special_tokens: bool,
     ):
         super().__init__()
 

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -54,7 +54,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
         # Setup the rollout store
         # Rollouts contain the prompt & response, log probs, values and rewards - from each rollout
-        self.store = PPORolloutStorage(self.tokenizer.pad_token_id)
+        self.store = PPORolloutStorage(self.tokenizer.pad_token_id, self.tokenizer.padding_side)
 
         # Create the rollout store dataloader (for batching up rollouts)
         # TODO (jon-tow): This is only used to satisfy to `accelerator.prepare` call constraint below - remove in future

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -95,8 +95,7 @@ def train(  # noqa: C901
             eval_prompts = prompts[:batch_size]
 
         pipeline = get_pipeline(config.train.pipeline)(
-            prompts, max_prompt_length, trainer.tokenizer,
-            add_special_tokens=config.model.model_arch_type == "seq2seq"
+            prompts, max_prompt_length, trainer.tokenizer, add_special_tokens=config.model.model_arch_type == "seq2seq"
         )
         trainer.add_prompt_pipeline(pipeline)
 
@@ -122,8 +121,7 @@ def train(  # noqa: C901
         raise ValueError("Either `samples` or `reward_fn` should be given for training")
 
     eval_pipeline = get_pipeline(config.train.pipeline)(
-        eval_prompts, max_prompt_length, trainer.tokenizer,
-        add_special_tokens=config.model.model_arch_type == "seq2seq"
+        eval_prompts, max_prompt_length, trainer.tokenizer, add_special_tokens=config.model.model_arch_type == "seq2seq"
     )
     trainer.add_eval_pipeline(eval_pipeline)
 

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -94,7 +94,10 @@ def train(  # noqa: C901
         if eval_prompts is None:
             eval_prompts = prompts[:batch_size]
 
-        pipeline = get_pipeline(config.train.pipeline)(prompts, max_prompt_length, trainer.tokenizer)
+        pipeline = get_pipeline(config.train.pipeline)(
+            prompts, max_prompt_length, trainer.tokenizer,
+            add_special_tokens=config.model.model_arch_type == "seq2seq"
+        )
         trainer.add_prompt_pipeline(pipeline)
 
         if eval_prompts is None:
@@ -118,7 +121,10 @@ def train(  # noqa: C901
     else:
         raise ValueError("Either `samples` or `reward_fn` should be given for training")
 
-    eval_pipeline = get_pipeline(config.train.pipeline)(eval_prompts, max_prompt_length, trainer.tokenizer)
+    eval_pipeline = get_pipeline(config.train.pipeline)(
+        eval_prompts, max_prompt_length, trainer.tokenizer,
+        add_special_tokens=config.model.model_arch_type == "seq2seq"
+    )
     trainer.add_eval_pipeline(eval_pipeline)
 
     trainer.learn()


### PR DESCRIPTION
The default T5 tokenizer will generate padded `input_ids` tensors like below (0 is BOS and PAD token, 1 is EOS token)

```
prompt = ["Some prompt</s><pad><pad>", "A longer prompt</s>"]
input_ids = [[123, 345, ..., 1, 0, 0], [543, 123, ..., 1]]
```

I think there was two issues that might cause the inputs to T5 to be a bit different than what the model is trained for

* The T5 example scripts didn't configure the `padding_side` for the tokenizer, so it defaults to "left" which caused prompts to be left-padded instead of right-padded
* The `PromptPipeline` class applied `add_special_tokens=False` when tokenizing prompts, causing the EOS `</s>` to not be added to the prompt for seq2seq models
