### PR TITLE
fix(CI): use pinned deps for CI testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev,bnb]"
+        pip install torch
+        pip install -r requirements.txt
+        # Install extras
+        # [bnb]
+        pip install bitsandbytes 
+        # [dev]
+        pip install black hypothesis isort flake8 pre-commit pytest pytest-cov
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install torch
         pip install -r requirements.txt
         # Install extras
         # [bnb]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         pip install -r requirements.txt
         # Install extras
         # [bnb]
-        pip install bitsandbytes 
+        pip install bitsandbytes
         # [dev]
         pip install black hypothesis isort flake8 pre-commit pytest pytest-cov
 


### PR DESCRIPTION
Use the pinned dependencies in `requirements.txt` for unit testing in CI re discussion in the recent trlx meeting.