### PR TITLE
fix(base_trainer): gather weights in `save_pretrained` under zero3

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -220,7 +220,7 @@ class TrainConfig:
     checkpoint_dir: str = "ckpts"
     rollout_logging_dir: Optional[str] = None
     save_best: bool = True
-    save_optimizer: bool = False
+    save_optimizer: bool = True
 
     tracker: Optional[str] = "wandb"
     logging_dir: Optional[str] = None

--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -220,6 +220,7 @@ class TrainConfig:
     checkpoint_dir: str = "ckpts"
     rollout_logging_dir: Optional[str] = None
     save_best: bool = True
+    save_optimizer: bool = False
 
     tracker: Optional[str] = "wandb"
     logging_dir: Optional[str] = None

--- a/trlx/models/modeling_base.py
+++ b/trlx/models/modeling_base.py
@@ -198,7 +198,7 @@ class PreTrainedModelWrapper(nn.Module, transformers.utils.PushToHubMixin):
                 Keyword arguments passed along to the underlying model's
                 `save_pretrained` method.
         """
-        state_dict = kwargs.pop("state_dict", None)
+        state_dict = kwargs.get("state_dict", None)
         if state_dict is None:
             state_dict = self.state_dict()
             kwargs["state_dict"] = state_dict

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -276,8 +276,16 @@ class AccelerateRLTrainer(BaseRLTrainer):
         """
         if directory is None:
             directory = os.path.join(self.config.train.checkpoint_dir, "hf_model")
+
         self.accelerator.wait_for_everyone()
-        self.accelerator.unwrap_model(self.model).save_pretrained(directory, **kwargs)
+        self.accelerator.unwrap_model(self.model).save_pretrained(
+            directory,
+            save_function=self.accelerator.save,
+            is_main_process=self.accelerator.is_main_process,
+            state_dict=self.accelerator.get_state_dict(self.model),
+            **kwargs,
+        )
+
         if self.accelerator.is_main_process:
             self.tokenizer.save_pretrained(directory)
 

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -543,7 +543,10 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     self.scheduler.step()
                     self.iter_count += 1
 
-                    if self.iter_count % self.config.train.checkpoint_interval == 0 or self.iter_count >= self.total_steps:
+                    if (
+                        self.iter_count % self.config.train.checkpoint_interval == 0
+                        or self.iter_count >= self.total_steps
+                    ):
                         subfolder = f"checkpoint_{self.iter_count:0{len(str(self.total_steps))}d}"
                         directory = os.path.join(self.config.train.checkpoint_dir, subfolder)
                         logger.info(f"Saving intermediate checkpoint into {directory}")

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -535,17 +535,21 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     self.scheduler.step()
                     self.iter_count += 1
 
-                    if self.iter_count % self.config.train.checkpoint_interval == 0:
+                    if self.iter_count % self.config.train.checkpoint_interval == 0 or self.iter_count >= self.total_steps:
                         subfolder = f"checkpoint_{self.iter_count:0{len(str(self.total_steps))}d}"
                         directory = os.path.join(self.config.train.checkpoint_dir, subfolder)
-                        self.save(directory)
+                        logger.info(f"Saving intermediate checkpoint into {directory}")
+                        if self.config.train.save_optimizer:
+                            self.save(directory)
+                        else:
+                            self.save_pretrained(directory)
 
                     stats["time/forward"] = forward_time
                     stats["time/backward"] = backward_time
                     for group_number, lr in enumerate(self.scheduler.get_last_lr()):
                         stats[f"learning_rate_group_{group_number}"] = lr
 
-                    if self.iter_count % self.config.train.eval_interval == 0:
+                    if self.iter_count % self.config.train.eval_interval == 0 or self.iter_count >= self.total_steps:
                         results = self.evaluate()
                         stats.update(results)
                         if ray.is_initialized():
@@ -566,28 +570,21 @@ class AccelerateRLTrainer(BaseRLTrainer):
                             if torch.distributed.is_initialized():
                                 torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
                             if do_save:
-                                best_path = f"{self.config.train.checkpoint_dir}/best_checkpoint"
-                                logger.info(f"Saving the best state so far into {best_path}")
-                                self.save(best_path)
+                                directory = os.path.join(self.config.train.checkpoint_dir, "best_checkpoint")
+                                logger.info(f"Saving the best state so far into {directory}")
+                                if self.config.train.save_optimizer:
+                                    self.save(directory)
+                                else:
+                                    self.save_pretrained(directory)
 
                     desc = " | ".join(f"{k}: {v:.2f}" for k, v in stats.items() if k.startswith("loss"))
                     tbar.set_description(f"[{desc}]")
                     tbar.update()
 
-                    if self.iter_count >= self.total_steps:
-                        subfolder = f"checkpoint_{self.iter_count:0{len(str(self.total_steps))}d}"
-                        directory = os.path.join(self.config.train.checkpoint_dir, subfolder)
-                        results = self.evaluate()
-                        stats.update(results)
-
-                        if ray.is_initialized():
-                            session.report(filter_non_scalars(stats), checkpoint=checkpoint)
-                        self.accelerator.log(stats, step=self.iter_count)
-
-                        self.save(directory)
-                        return results
-
                     self.accelerator.log(stats, step=self.iter_count)
+
+                    if self.iter_count >= self.total_steps:
+                        return results
 
                 self.post_backward_callback()
 


### PR DESCRIPTION
This PR lets users optionally choose whether to save optimizer state on each and a final checkpoint or only the model weights via `trainer.save_pretrained` (new default). Also this PR removes two back to back calls to `trainer.evaluate`, which would happen on the same `iter_count` in the case `total_steps` is divisible by `config.train.eval_interval`. And it fixes `trainer.save_pretrained`, in which under zero3, weights weren't gathered previously into the `state_dict`.

https://wandb.ai/sorry/trlx-references/reports/fix-save-pretrained-zero3-v-main--Vmlldzo0MDI1ODk1
