### PR TITLE
fix(sft_trainer): `total_steps` calculation when running distributed

### DIFF
--- a/trlx/trainer/accelerate_sft_trainer.py
+++ b/trlx/trainer/accelerate_sft_trainer.py
@@ -64,7 +64,7 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
         ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
 
         self.n_updates_per_batch = 1
-        self.total_steps = self.config.train.epochs * len(train_dataloader)
+        self.total_steps = self.config.train.epochs * len(self.train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
 
     def make_experience(self, samples, seq_length):


### PR DESCRIPTION
Fix of #426, the same error as in #374