### PR TITLE
fix(offline_pipeline): ILQL negative indexing under truncation

### DIFF
--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -28,7 +28,6 @@ class TestTokenizeDialog(TestCase):
         assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
         assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
 
-
     @given(st.lists(st.text(), max_size=32))
     def test_tokenize_dialogue_single_turn(self, response_words):
         response = " ".join(response_words)  # space seperate to make it multiple tokens

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -11,22 +11,18 @@ class TestTokenizeDialog(TestCase):
     def setUp(self):
         self.tokenizer = AutoTokenizer.from_pretrained("gpt2")
 
-    def test_tokenize_dialogue_truncation(self):
-        dialogue = ["will be truncated", "ø" * 1024]
+    def test_tokenize_dialogue_truncation_basic(self):
+        dialogue = ["this will be truncated", "."]
         self.tokenizer.truncation_side = "left"
 
-        tokenized_response = tuple(self.tokenizer("ø" * 1024, add_special_tokens=False).input_ids)
-        tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
-        tokenized_response = tokenized_response[-1023:]
-        dialog = tokenize_dialogue(dialogue, self.tokenizer, max_length=1024)
+        dialog = tokenize_dialogue(dialogue, self.tokenizer, max_length=2)
 
         assert len(dialog) == 2
         user_dm, bot_dm = dialog
         assert len(user_dm.tokens) == 1
-        assert len(bot_dm.tokens) == 1023
-        assert bot_dm.tokens[-1] == self.tokenizer.eos_token_id
+        assert len(bot_dm.tokens) == 1
         assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
-        assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
+        assert bot_dm == DialogMessage(is_output=True, tokens=(self.tokenizer.eos_token_id,))
 
     @given(st.lists(st.text(), max_size=32))
     def test_tokenize_dialogue_single_turn(self, response_words):
@@ -63,20 +59,18 @@ class TestTokenizeDialog(TestCase):
         response = " ".join(response_words)  # space seperate to make it multiple tokens
         self.tokenizer.truncation_side = "left"
         tokenized_response = tuple(self.tokenizer(response, add_special_tokens=False).input_ids)
-        tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
+        tokenized_response += (self.tokenizer.eos_token_id,)
         dialog = tokenize_dialogue(response, self.tokenizer, max_length=max_length)
 
-        # if no truncation should have happened, then the user BOS prompt should be present
-        if len(tokenized_response) + 1 <= max_length:
-            assert len(dialog) == 2
-            user_dm, bot_dm = dialog
+        # whether or not truncation has happened, user BOS prompt should be present
+        assert len(dialog) == 2
+        user_dm, bot_dm = dialog
+        assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
 
-            assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
+        if len(tokenized_response) < max_length:
             assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
         else:
-            assert len(dialog) == 1
-            bot_dm = dialog[0]
-            assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response[-max_length:])
+            assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response[-max_length + 1 :])
 
         all_tokens = sum((dm.tokens for dm in dialog), ())
         assert len(all_tokens) <= max_length
@@ -93,6 +87,9 @@ class TestTokenizeDialog(TestCase):
 
         dm_convo = [DialogMessage(is_output=i % 2 == 1, tokens=tokens) for i, tokens in enumerate(tokenized_flat_convo)]
         nonempty_dm_convo = [dm for dm in dm_convo if dm.tokens]
+        if nonempty_dm_convo[0].is_output:
+            nonempty_dm_convo.insert(0, DialogMessage(is_output=False, tokens=(self.tokenizer.eos_token_id,)))
+
         assert dialog == nonempty_dm_convo
 
     @given(st.lists(st.tuples(st.text(), st.text()), min_size=1, max_size=32), st.integers(min_value=2, max_value=16))
@@ -108,6 +105,9 @@ class TestTokenizeDialog(TestCase):
 
         all_tokens = sum((dm.tokens for dm in dialog), ())
         should_be_tokens = sum(tokenized_flat_convo, ())[:max_length]
+        if dialog[0] == DialogMessage(is_output=False, tokens=(self.tokenizer.eos_token_id,)):
+            should_be_tokens = (self.tokenizer.eos_token_id, *should_be_tokens[: max_length - 1])
+
         assert all_tokens == should_be_tokens
         assert len(all_tokens) <= max_length
 
@@ -123,8 +123,9 @@ class TestTokenizeDialog(TestCase):
         dialog = tokenize_dialogue(flat_convo, self.tokenizer, max_length=max_length)
 
         all_tokens = sum((dm.tokens for dm in dialog), ())
-
         should_be_tokens = sum(tokenized_flat_convo, ())[-max_length:]
-        assert all_tokens == should_be_tokens
+        if dialog[0] == DialogMessage(is_output=False, tokens=(self.tokenizer.eos_token_id,)):
+            should_be_tokens = (self.tokenizer.eos_token_id, *should_be_tokens[-max_length + 1 :])
 
+        assert all_tokens == should_be_tokens
         assert len(all_tokens) <= max_length

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -13,14 +13,18 @@ class TestTokenizeDialog(TestCase):
 
     def test_tokenize_dialogue_truncation(self):
         dialogue = ["will be truncated", "ø" * 1024]
+        self.tokenizer.truncation_side = "left"
 
-        tokenized_response = tuple(self.tokenizer("ø" * 1023, add_special_tokens=False).input_ids)
+        tokenized_response = tuple(self.tokenizer("ø" * 1024, add_special_tokens=False).input_ids)
         tokenized_response = tokenized_response + (self.tokenizer.eos_token_id,)
-        dialog = tokenize_dialogue(dialogue, self.tokenizer)
+        tokenized_response = tokenized_response[-1023:]
+        dialog = tokenize_dialogue(dialogue, self.tokenizer, max_length=1024)
 
         assert len(dialog) == 2
         user_dm, bot_dm = dialog
-
+        assert len(user_dm.tokens) == 1
+        assert len(bot_dm.tokens) == 1023
+        assert bot_dm.tokens[-1] == self.tokenizer.eos_token_id
         assert user_dm == DialogMessage(is_output=False, tokens=(self.tokenizer.bos_token_id,))
         assert bot_dm == DialogMessage(is_output=True, tokens=tokenized_response)
 

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -26,7 +26,7 @@ class DialogMessage:
 
 
 def tokenize_dialogue(  # noqa: C901
-    dialogue: Union[str, List[str]], tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], max_length=2048
+    dialogue: Union[str, Iterable[str]], tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast], max_length=2048
 ) -> List[DialogMessage]:
     """
     Tokenize sample with the interleaved form of (prompt_1, output_1, prompt_2, output_2...)

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -64,9 +64,14 @@ def tokenize_dialogue(  # noqa: C901
         truncated = [DialogMessage(is_output=m.is_output, tokens=m.tokens[::-1]) for m in truncated[::-1]]
 
     # remove empty messages
-    truncated = [t for t in truncated if len(t.tokens) > 0]
+    out = [t for t in truncated if len(t.tokens) > 0]
 
-    return truncated
+    if len(out) % 2 == 1:
+        if sum(map(lambda msg: len(msg.tokens), out)) == max_length:
+            out[0].tokens = out[0].tokens[1:]
+        out.insert(0, DialogMessage(False, (tokenizer.bos_token_id,)))
+
+    return out
 
 
 class DialogStore(BaseRolloutStore):


### PR DESCRIPTION
This PR fixes a bug under which it was possible to run into negative indices with tokenizer's left truncation

https://wandb.ai/sorry/trlx/runs/yn59xu9i
