### PR TITLE
fix(base_trainer): flatten tag list for tensorboard hparams logging

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -117,6 +117,9 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 config_dict_flat["optimizer/kwargs/beta_1"] = config_dict_flat["optimizer/kwargs/betas"][0]
                 config_dict_flat["optimizer/kwargs/beta_2"] = config_dict_flat["optimizer/kwargs/betas"][1]
                 config_dict_flat.pop("optimizer/kwargs/betas", None)
+                for ix, tag in enumerate(config_dict_flat.pop("train/tags")):
+                    config_dict_flat[f"train/tag_{ix}"] = tag
+
                 self.accelerator.init_trackers(
                     project_name=self.config.train.project_name,
                     config=config_dict_flat,


### PR DESCRIPTION
Fix of #437 

This is the command to reproduce the issue (or its resolution):
```bash
python examples/randomwalks/ppo_randomwalks.py '{"train": {"tracker": "tensorboard", "logging_dir": "tensorboard-dir", "tags": ["0"], "total_steps": 1}}'
```
