### PR TITLE
fix(ppo_gpt): prevent position_ids being None

### DIFF
--- a/examples/hh/README.md
+++ b/examples/hh/README.md
@@ -6,7 +6,7 @@ Launch training of [GPT-J](https://huggingface.co/EleutherAI/gpt-j-6B) on 7 GPUs
 ```sh
 accelerate launch --num_processes 7 --config_file ../../configs/accelerate/zero2-bf16.yaml ppo_hh.py
 ```
-Or if you want to train a smaller model or start from a supervised checkpoint, you can use one of the [configs](./configs)
+Or if you want to train a smaller model or start from a supervised checkpoint, you can use one of the [configs](../../configs)
 ```sh
 CONFIG_NAME=125M accelerate launch --num_processes 7 --config_file ../../configs/accelerate/zero2-bf16.yaml ppo_hh.py
 ```

--- a/trlx/models/modeling_ppo.py
+++ b/trlx/models/modeling_ppo.py
@@ -524,7 +524,7 @@ class GPTModelBranch(ModelBranch):
                 kwargs.pop("encoder_hidden_states")
                 kwargs.pop("encoder_attention_mask")
             # Remove position_ids for GPT2Block
-            elif "position_ids" not in block_params:
+            if "position_ids" not in block_params:
                 kwargs.pop("position_ids")
 
             outputs = block(hidden_states, **kwargs)

--- a/trlx/models/modeling_ppo.py
+++ b/trlx/models/modeling_ppo.py
@@ -602,11 +602,17 @@ class OPTModelBranch(ModelBranch):
         input_shape = hidden_states.size()[:-1]
         combined_attention_mask = None
         if input_shape[-1] > 1:
+            # `modeling_opt._make_causal_mask` @ transformers==4.27.1 doesn't have the `device` argument
+            if "device" in inspect.getfullargspec(modeling_opt._make_causal_mask).args:
+                kwargs = dict(device=hidden_state.device)
+            else:
+                kwargs = {}
+
             combined_attention_mask = modeling_opt._make_causal_mask(
                 input_shape,
                 hidden_states.dtype,
                 past_key_values_length=past_key_values_length,
-                device=attention_mask.device,
+                **kwargs,
             ).to(hidden_states.device)
 
         if attention_mask is not None:

--- a/trlx/models/modeling_ppo.py
+++ b/trlx/models/modeling_ppo.py
@@ -606,6 +606,7 @@ class OPTModelBranch(ModelBranch):
                 input_shape,
                 hidden_states.dtype,
                 past_key_values_length=past_key_values_length,
+                device=attention_mask.device,
             ).to(hidden_states.device)
 
         if attention_mask is not None:


### PR DESCRIPTION
This PR fixes the below error during PPO training, by generating the correct `position_ids` when it is None.

The PPO training was launched by:
```sh
accelerate launch --num_processes 7 --config_file ../../configs/accelerate/zero2-bf16.yaml ppo_hh.py
```
The below error was raised:
```
Traceback (most recent call last):
  File "/data00/home/lijiahao.plus/deepspeed/trlx/examples/hh/ppo_hh.py", line 227, in <module>
    main(hparams)
  File "/data00/home/lijiahao.plus/deepspeed/trlx/examples/hh/ppo_hh.py", line 216, in main
    trlx.train(
  File "/data00/home/lijiahao.plus/deepspeed/trlx/trlx/trlx.py", line 103, in train
    trainer.make_experience(config.method.num_rollouts)
  File "/data00/home/lijiahao.plus/deepspeed/trlx/trlx/trainer/accelerate_ppo_trainer.py", line 408, in make_experience
    ref_logits = self.model.forward_hydra(
  File "/data00/home/lijiahao.plus/deepspeed/trlx/trlx/models/modeling_ppo.py", line 387, in forward_hydra
    hydra_outputs = self.frozen_head(input_hidden_state, output_shape, **forward_kwargs)
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data00/home/lijiahao.plus/deepspeed/trlx/trlx/models/modeling_ppo.py", line 515, in forward
    outputs = block(
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/transformers/models/gpt_neox/modeling_gpt_neox.py", line 320, in forward
    attention_layer_outputs = self.attention(
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/transformers/models/gpt_neox/modeling_gpt_neox.py", line 139, in forward
    query, key = apply_rotary_pos_emb(query_rot, key_rot, cos, sin, position_ids)
  File "/data00/home/lijiahao.plus/miniconda3/envs/mlir/lib/python3.9/site-packages/transformers/models/gpt_neox/modeling_gpt_neox.py", line 278, in apply_rotary_pos_emb
    gather_indices = position_ids[:, None, :, None]  # [bs, 1, seq_len, 1]
TypeError: 'NoneType' object is not subscriptable
```
