### PR TITLE
Upgrade official released Ray instead of an unstable one.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.10
 pytz==2022.7.1
 PyYAML==6.0
-ray==2.3.0
+ray==2.4.0
 regex==2022.10.31
 requests==2.28.2
 responses==0.18.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,12 +23,10 @@ install_requires =
     tqdm
     rich
     wandb>=0.13.5
+    ray>=2.4.0
     tabulate>=0.9.0
     networkx
     tritonclient
-    ray@https://ray-ci-artifact-branch-public.s3.amazonaws.com/42bb0357a6fb13e4994789c824f3623f32869ad8/tmp/artifacts/.whl/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl ; python_version=="3.8"
-    ray@https://ray-ci-artifact-branch-public.s3.amazonaws.com/42bb0357a6fb13e4994789c824f3623f32869ad8/tmp/artifacts/.whl/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl ; python_version=="3.9"
-    ray@https://ray-ci-artifact-branch-public.s3.amazonaws.com/42bb0357a6fb13e4994789c824f3623f32869ad8/tmp/artifacts/.whl/ray-3.0.0.dev0-cp310-cp310-manylinux2014_x86_64.whl ; python_version=="3.10"
 
 [options.extras_require]
 bnb = bitsandbytes


### PR DESCRIPTION
As the Ray-2.4.0 was released with the necessary commits we need, let us upgrade the official released version.