### PR TITLE
fix(trainer): init self.generate_sweep_kwarg at self.__init__

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -129,10 +129,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     "Set `tracker` to `None` to disable tracking."
                 )
 
-        self.setup_generate_sweep_kwarg()
         self.nth_evaluation = 0
-
-    def setup_generate_sweep_kwarg(self):
         self.generate_sweep_kwarg = None
         for k, v in self.config.method.gen_kwargs.items():
             if isinstance(v, list):

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -130,6 +130,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                 )
 
         self.generate_sweep_kwarg = None
+        self.nth_evaluation = 0
 
     def setup_model(self):
         """

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -129,6 +129,8 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     "Set `tracker` to `None` to disable tracking."
                 )
 
+        self.generate_sweep_kwarg = None
+
     def setup_model(self):
         """
         Returns a model derived from an instance's TRLConfig
@@ -478,7 +480,6 @@ class AccelerateRLTrainer(BaseRLTrainer):
         """
         logger.info("Starting training")
 
-        self.generate_sweep_kwarg = None
         for k, v in self.config.method.gen_kwargs.items():
             if isinstance(v, list):
                 if self.generate_sweep_kwarg is not None:


### PR DESCRIPTION
If we do `trainer.evaluate()` before `trainer.learn()`, it will rasie `AttributeError` like:
```
│ ❱ 310 │   │   if self.generate_sweep_kwarg is not None:                                          │
│   311 │   │   │   gen_sweep_arg, gen_sweep_values = self.generate_sweep_kwarg                    │
│   312 │   │   else:                                                                              │
│   313 │   │   │   gen_sweep_values = [None]                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'AccelerateILQLTrainer' object has no attribute 'generate_sweep_kwarg'
```

so, I think it's better to initialize `generate_sweep_kwarg` with the initialization of the `trainer`

And the same with `self.nth_evaluation`