### PR TITLE
fix(modeling_ilql): single q-head indexing

### DIFF
--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -469,7 +469,7 @@ class AutoModelForSeq2SeqLMWithILQLHeads(PreTrainedModelWrapper):
             if self.two_qs:
                 qs = torch.minimum(target_qs[0][:, -1, :], target_qs[1][:, -1, :])
             else:
-                qs = target_qs[:, -1, :]
+                qs = target_qs[0][:, -1, :]
 
             logits = logits[:, -1, :]
             vs = vs[:, -1, :]

--- a/trlx/models/modeling_ilql.py
+++ b/trlx/models/modeling_ilql.py
@@ -289,7 +289,7 @@ class AutoModelForCausalLMWithILQLHeads(PreTrainedModelWrapper):
             if self.two_qs:
                 qs = torch.minimum(target_qs[0][:, -1, :], target_qs[1][:, -1, :])
             else:
-                qs = target_qs[:, -1, :]
+                qs = target_qs[0][:, -1, :]
 
             logits = logits[:, -1, :]
             vs = vs[:, -1, :]


### PR DESCRIPTION
This PR fixes an indexing error when using a single q-head instead of two.
To reproduce the error on main: `python examples/randomwalks/ilql_randomwalks.py '{"method": {"two_qs": false}}'`

https://wandb.ai/sorry/trlx/reports/Single-Q-vs-two-Qs-on-randomwalks--Vmlldzo0MzA2NTc2