### PR TITLE
fix(offline_pipeline): force `drop_last` only for distributed

### DIFF
--- a/trlx/pipeline/__init__.py
+++ b/trlx/pipeline/__init__.py
@@ -126,6 +126,10 @@ class MiniBatchIterator:
 
     def __next__(self):
         batch = next(self.data_loader_iter)
+        if batch is None:
+            logger.warning("WARNING: Not enough samples to saturate the minibatch size. Increase the number of prompts or samples or decrease the minibatch size.")
+            raise StopIteration
+
         minibatches = []
 
         for mbi in range(self.num_mb):
@@ -138,7 +142,7 @@ class MiniBatchIterator:
                 end_idx = (mbi + 1) * self.mb_size
                 sliced_data[key] = value[start_idx:end_idx]
 
-                if len(sliced_data[key]) == 0:
+                if self.num_mb > 1 and len(sliced_data[key]) == 0:
                     logger.warning(
                         "WARNING: MiniBatchIterator generated a minibatch with 0 elements. "
                         "This may be due to the wrong mb_size and/or num_mb or the last batch"
@@ -146,7 +150,7 @@ class MiniBatchIterator:
                     )
                     sliced_data.pop(key)
                     break
-                elif len(sliced_data[key]) < self.mb_size:
+                elif self.num_mb > 1 and len(sliced_data[key]) < self.mb_size:
                     logger.warning(
                         "WARNING: MiniBatchIterator generated a minibatch with fewer elements than mb_size. "
                         "This may be due to the wrong mb_size and/or num_mb or the last batch in the dataset "

--- a/trlx/pipeline/offline_pipeline.py
+++ b/trlx/pipeline/offline_pipeline.py
@@ -207,13 +207,13 @@ class ILQLRolloutStorage(BaseRolloutStore):
     def __len__(self) -> int:
         return len(self.input_ids)
 
-    def create_loader(self, batch_size: int, drop_last=True):
+    def create_loader(self, batch_size: int):
         return DataLoader(
             self,
             batch_size=batch_size,
             shuffle=True,
             collate_fn=ilql_collate_fn,
-            drop_last=drop_last,
+            drop_last=torch.distributed.is_initialized(),
         )
 
 
@@ -259,11 +259,11 @@ class ILQLSeq2SeqRolloutStorage(BaseRolloutStore):
     def __len__(self) -> int:
         return len(self.input_ids)
 
-    def create_loader(self, batch_size: int, drop_last=True):
+    def create_loader(self, batch_size: int):
         return DataLoader(
             self,
             batch_size=batch_size,
             shuffle=True,
             collate_fn=ilql_seq2seq_collate_fn,
-            drop_last=drop_last,
+            drop_last=torch.distributed.is_initialized(),
         )


### PR DESCRIPTION
This PR keeps `drop_last` policy for dataloaders only for multiprocess training to avoid duplication, but keeps last batches for single processes to avoid losing data. It also skips warning messages that `MiniBatchIterator` could throw even though minibatching is not actived, for example when running `python examples/randomwalks/ppo_randomwalks.py` on the current `main`

Fix of #473 