### PR TITLE
fix(modeling): deepspeed checkpoint loading

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -221,6 +221,7 @@ class TrainConfig:
     rollout_logging_dir: Optional[str] = None
     save_best: bool = True
     save_optimizer: bool = True
+    resume_from_checkpoint: Optional[str] = None
 
     tracker: Optional[str] = "wandb"
     logging_dir: Optional[str] = None

--- a/trlx/trlx.py
+++ b/trlx/trlx.py
@@ -23,6 +23,7 @@ def train(  # noqa: C901
     metric_fn: Optional[Callable[[List[str], List[str], List[str]], Dict[str, List[float]]]] = None,
     config: Optional[TRLConfig] = None,
     stop_sequences: Optional[List[str]] = [],
+    resume_from: Optional[str] = None,
 ):
     """
     Dispatches online, offline reinforcement training or supervised finetuning
@@ -124,6 +125,9 @@ def train(  # noqa: C901
         eval_prompts, max_prompt_length, trainer.tokenizer, add_special_tokens=config.model.model_arch_type == "seq2seq"
     )
     trainer.add_eval_pipeline(eval_pipeline)
+
+    if config.train.resume_from_checkpoint and os.path.exists(config.train.resume_from_checkpoint):
+        trainer.load(config.train.resume_from_checkpoint)
 
     trainer.learn()
     return trainer


### PR DESCRIPTION
This PR adds an option to load and resume training from previously saved deepspeed checkpoints

Example of successive training:
```bash
accelerate launch --config_file configs/accelerate/zero2-bf16.yaml examples/randomwalks/ppo_randomwalks.py
accelerate launch --config_file configs/accelerate/zero2-bf16.yaml examples/randomwalks/ppo_randomwalks.py '{"train": {"resume_from_checkpoint": "ckpts/best_checkpoint"}}'
```

- [ ] Verify multinode ZeRO3 loading
- [ ] Update docstrings