### PR TITLE
fix(modeling_ppo): load reference head under zero3

### DIFF
--- a/trlx/models/modeling_ppo.py
+++ b/trlx/models/modeling_ppo.py
@@ -1,13 +1,12 @@
 import gc
-import deepspeed
 import inspect
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import List, Optional, Tuple, Union
 
+import deepspeed
 import numpy as np
 import torch
-import torch.nn as nn
 import transformers
 from torchtyping import TensorType
 from transformers.modeling_outputs import ModelOutput
@@ -416,7 +415,10 @@ class ModelBranch(transformers.PreTrainedModel):
         final_norm = hf_get_decoder_final_norm(base_model)
         lm_head = hf_get_lm_head(base_model)
 
-        with deepspeed.zero.GatheredParameters(list(decoder_blocks.parameters()) + list(final_norm.parameters()) + list(lm_head.parameters()), modifier_rank=None):
+        with deepspeed.zero.GatheredParameters(
+            list(decoder_blocks.parameters()) + list(final_norm.parameters()) + list(lm_head.parameters()),
+            modifier_rank=None,
+        ):
             self.decoder_blocks = deepcopy(decoder_blocks)
             self.final_norm = deepcopy(final_norm)
             self.lm_head = deepcopy(lm_head)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -539,7 +539,9 @@ class AccelerateRLTrainer(BaseRLTrainer):
                             loss, stats = self.loss(mb)
                             forward_time += time()
                             backward_time -= time()
+                            self.model.train()
                             self.accelerator.backward(loss)
+                            self.model.eval()
                             backward_time += time()
                             stats_accum.append(stats)
 

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -88,6 +88,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             use_cache=True,
             eos_token_id=self.tokenizer.eos_token_id,
             pad_token_id=self.tokenizer.pad_token_id,
+            synced_gpus=self.accelerator.deepspeed_config["zero_optimization"]["stage"] == 3,
         )
         self.generate_kwargs = {**generate_kwargs, **config.method.gen_kwargs}
 

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -88,7 +88,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             use_cache=True,
             eos_token_id=self.tokenizer.eos_token_id,
             pad_token_id=self.tokenizer.pad_token_id,
-            synced_gpus=self.accelerator.deepspeed_config["zero_optimization"]["stage"] == 3,
+            synced_gpus=os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE") == "3",
         )
         self.generate_kwargs = {**generate_kwargs, **config.method.gen_kwargs}
 


### PR DESCRIPTION
Fix of #461 #483

Under zero3 the reference head will be kept unsharded. I couldn't get sharding to work because deepspeed expects sharded parameters to have at least one backward pass, while there is no backward pass for the reference head.

Check:
```bash
accelerate launch --config_file configs/accelerate/zero3.yaml examples/ppo_sentiments.py
```

https://wandb.ai/sorry/trlx-references/reports/fix-ppo-zero3-v-main--Vmlldzo0NjY3MDYy