### PR TITLE
hotfix(bnb): install `scipy` with `bitsanbytes` to avoid `ModuleNotFoundError`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         # Install extras
-        # [bnb]
-        pip install bitsandbytes
+        # [bnb] (TODO: Remove `scipy` once `bnb` adds it as hard dep)
+        pip install bitsandbytes scipy
         # [dev]
         pip install black hypothesis isort flake8 pre-commit pytest pytest-cov
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,9 @@ install_requires =
     tritonclient
 
 [options.extras_require]
-bnb = bitsandbytes
+bnb =
+    bitsandbytes
+    scipy  # fix(bnb): Remove when `bitsandbytes` adds this dependency
 dev =
     black
     hypothesis


### PR DESCRIPTION
The latest `bitsandbytes` requires `scipy` for a `norm` calculation but does not make it a dependency.