### PR TITLE
Fix deprecated arguments for Accelerate >= v0.20.0

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -55,7 +55,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
             self.mb_size = config.train.batch_size
         self.num_mb = config.train.batch_size // self.mb_size
         self.mb_count = 0
-        self.accelerator = Accelerator(log_with=config.train.tracker, logging_dir=config.train.logging_dir)
+        self.accelerator = Accelerator(log_with=config.train.tracker, project_dir=config.train.logging_dir)
 
         if self.accelerator.state.deepspeed_plugin is not None:
             # by accelerate's default, arguments in `model.forward` would be casted to half


### PR DESCRIPTION
The current `AccelerateSFTTrainer` gives `logging_dir` argument to `Accelerator`'s constructor, which does not work with recent accelerate versions (>= v0.20.0). This PR fixes this issue.

Argument `logging_dir` is replaced by a new argument `project_dir`. Argument `project_dir` is introduced in v0.16.0, and `logging_dir` is removed in v0.20.0. As we specify `accelerate>=0.17.1` in `setup.cfg`, we can safely use `project_dir`.

## References

* https://github.com/huggingface/accelerate/pull/916
* https://github.com/huggingface/accelerate/pull/1537#issue-1743728109
* https://github.com/huggingface/accelerate/releases/tag/v0.16.0
* https://github.com/huggingface/accelerate/releases/tag/v0.20.0


## Full error

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ .../trlx/examples/sft_sentiments.py:50 in <module>                     │
│                                                                                                  │
│   47                                                                                             │
│   48 if __name__ == "__main__":                                                                  │
│   49 │   hparams = {} if len(sys.argv) == 1 else json.loads(sys.argv[1])                         │
│ ❱ 50 │   main(hparams)                                                                           │
│   51                                                                                             │
│                                                                                                  │
│ .../trlx/examples/sft_sentiments.py:39 in main                         │
│                                                                                                  │
│   36 │   │   sentiments = list(map(get_positive_score, sentiment_fn(samples)))                   │
│   37 │   │   return {"sentiments": sentiments}                                                   │
│   38 │                                                                                           │
│ ❱ 39 │   trainer = trlx.train(                                                                   │
│   40 │   │   samples=imdb["text"],                                                               │
│   41 │   │   eval_prompts=["I don't know much about Hungarian underground"] * 64,                │
│   42 │   │   metric_fn=metric_fn,                                                                │
│                                                                                                  │
│ .../trlx/trlx/trlx.py:79 in train                                      │
│                                                                                                  │
│    76 │   if model_path:                                                                         │
│    77 │   │   config.model.model_path = model_path                                               │
│    78 │                                                                                          │
│ ❱  79 │   trainer = get_trainer(config.train.trainer)(                                           │
│    80 │   │   config=config,                                                                     │
│    81 │   │   reward_fn=reward_fn,                                                               │
│    82 │   │   metric_fn=metric_fn,                                                               │
│                                                                                                  │
│ .../trlx/trlx/trainer/accelerate_sft_trainer.py:32 in __init__         │
│                                                                                                  │
│   29 @register_trainer                                                                           │
│   30 class AccelerateSFTTrainer(AccelerateRLTrainer):                                            │
│   31 │   def __init__(self, config: TRLConfig, **kwargs):                                        │
│ ❱ 32 │   │   super().__init__(config, **kwargs)                                                  │
│   33 │   │                                                                                       │
│   34 │   │   self.generate_kwargs = dict(                                                        │
│   35 │   │   │   config.method.gen_kwargs,                                                       │
│                                                                                                  │
│ .../trlx/trlx/trainer/accelerate_base_trainer.py:58 in __init__        │
│                                                                                                  │
│    55 │   │   │   self.mb_size = config.train.batch_size                                         │
│    56 │   │   self.num_mb = config.train.batch_size // self.mb_size                              │
│    57 │   │   self.mb_count = 0                                                                  │
│ ❱  58 │   │   self.accelerator = Accelerator(log_with=config.train.tracker, logging_dir=config   │
│    59 │   │                                                                                      │
│    60 │   │   if self.accelerator.state.deepspeed_plugin is not None:                            │
│    61 │   │   │   # by accelerate's default, arguments in `model.forward` would be casted to h   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: __init__() got an unexpected keyword argument 'logging_dir'
```
