### PR TITLE
fix(modeling_base): handle parent directory for peft head save

### DIFF
--- a/trlx/models/modeling_base.py
+++ b/trlx/models/modeling_base.py
@@ -336,6 +336,7 @@ class PreTrainedModelWrapper(nn.Module, transformers.utils.PushToHubMixin):
 
         if self.peft_type:
             # Save the heads, which are not part of the peft adapter
+            os.makedirs(args[0], exist_ok=True)
             save_path = os.path.join(args[0], "pytorch_model.bin")
             head_state_dict = self.state_dict(heads_only=True)
 


### PR DESCRIPTION
Parent directory not found error occurs in ppo training, because `torch.save` won't handle the save path for us(https://github.com/pytorch/pytorch/issues/71389). 