### PR TITLE
Fix ordering of ppo epoch iteration

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -645,11 +645,10 @@ class AccelerateRLTrainer(BaseRLTrainer):
             self.post_epoch_callback()
         tbar.close()
 
-    def create_train_dataloader(self, shuffle=True, accelerate_prepare=True):
-        dataloader = self.store.create_loader(self.config.train.batch_size, shuffle=shuffle)
-        if accelerate_prepare:
-            dataloader = self.accelerator.prepare_dataloader(dataloader)
-        return dataloader
+    @abstractmethod
+    def create_train_dataloader(self):
+        """Returns a new dataloader for training."""
+        pass
 
     @abstractmethod
     def get_arch(self, config: TRLConfig):

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -542,21 +542,21 @@ class AccelerateRLTrainer(BaseRLTrainer):
 
         # For each epoch
         for _ in range(self.config.train.epochs):
-            # For each batch
-            for mbs in MiniBatchIterator(self.train_dataloader, self.mb_size, self.num_mb):
-                # For each update per batch
-                for _ in range(self.n_updates_per_batch):
-                    # Note that whereas standard policy gradient methods perform one
-                    # gradient update per batch, PPO for example commonly performs
-                    # multiple gradient updates on the same batch of data.
-                    # https://arxiv.org/pdf/1707.06347.pdf
-                    forward_time = 0
-                    backward_time = 0
+            # For each ppo epoch
+            for _ in range(self.n_inner_epochs):
+                # Note that whereas standard policy gradient methods perform one
+                # gradient update per batch, PPO for example commonly performs
+                # multiple epochs of gradient updates on the same batch of data.
+                # https://arxiv.org/pdf/1707.06347.pdf
+                # For each batch
+                for minibatch in MiniBatchIterator(list(self.train_dataloader), self.mb_size, self.num_mb):
+                    forward_time = 0.0
+                    backward_time = 0.0
                     stats_accum = []
-                    for mb in mbs:
+                    for microbatch in minibatch:
                         with self._accumulate():
                             forward_time -= time()
-                            loss, stats = self.loss(mb)
+                            loss, stats = self.loss(microbatch)
                             forward_time += time()
                             backward_time -= time()
                             self.accelerator.backward(loss)

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -169,7 +169,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
             self.eval_dataloader,
         ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
 
-        self.n_updates_per_batch = 1
+        self.n_inner_epochs = 1
         self.total_steps = self.config.train.epochs * len(self.train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
 

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -159,7 +159,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         return self.ilql.loss((logits, (qs, target_qs, vs)), batch)
 
     def create_train_dataloader(self):
-        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size))
+        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size, shuffle=True))
 
     def prepare_learning(self):
         self.train_dataloader = self.create_train_dataloader()

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -159,7 +159,7 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
         return self.ilql.loss((logits, (qs, target_qs, vs)), batch)
 
     def create_train_dataloader(self):
-        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size, shuffle=True))
+        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size))
 
     def prepare_learning(self):
         self.train_dataloader = self.create_train_dataloader()

--- a/trlx/trainer/accelerate_ilql_trainer.py
+++ b/trlx/trainer/accelerate_ilql_trainer.py
@@ -158,16 +158,18 @@ class AccelerateILQLTrainer(AccelerateRLTrainer):
 
         return self.ilql.loss((logits, (qs, target_qs, vs)), batch)
 
+    def create_train_dataloader(self):
+        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size))
+
     def prepare_learning(self):
-        train_dataloader = self.store.create_loader(self.config.train.batch_size)
+        self.train_dataloader = self.create_train_dataloader()
         eval_dataloader = self.eval_pipeline.create_loader(self.config.train.batch_size)
 
         (
             self.model,
             self.opt,
-            self.train_dataloader,
             self.eval_dataloader,
-        ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
+        ) = self.accelerator.prepare(self.model, self.opt, eval_dataloader)
 
         self.n_inner_epochs = 1
         self.total_steps = self.config.train.epochs * len(self.train_dataloader)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -228,8 +228,8 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
         self.train_dataloader = self.store.create_loader(self.config.train.batch_size, shuffle=False)
 
-        self.n_updates_per_batch = self.config.method.ppo_epochs
-        self.total_steps = self.config.train.epochs * self.n_updates_per_batch * len(self.train_dataloader)
+        self.n_inner_epochs = self.config.method.ppo_epochs
+        self.total_steps = self.config.train.epochs * self.n_inner_epochs * len(self.train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
 
     def add_prompt_pipeline(self, pipeline: PromptPipeline):

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -220,13 +220,16 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
     def post_backward_callback(self):
         self.kl_ctl.update(self.mean_kl, n_steps=self.config.train.batch_size)
 
+    def create_train_dataloader(self):
+        return self.store.create_loader(self.config.train.batch_size)
+
     def prepare_learning(self):
         eval_dataloader = self.eval_pipeline.create_loader(self.config.method.chunk_size)
         self.eval_dataloader = self.accelerator.prepare_data_loader(eval_dataloader)
 
         self.make_experience(self.config.method.num_rollouts)
 
-        self.train_dataloader = self.store.create_loader(self.config.train.batch_size, shuffle=False)
+        self.train_dataloader = self.create_train_dataloader()
 
         self.n_inner_epochs = self.config.method.ppo_epochs
         self.total_steps = self.config.train.epochs * self.n_inner_epochs * len(self.train_dataloader)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -221,7 +221,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
         self.kl_ctl.update(self.mean_kl, n_steps=self.config.train.batch_size)
 
     def create_train_dataloader(self):
-        return self.store.create_loader(self.config.train.batch_size)
+        return self.store.create_loader(self.config.train.batch_size, shuffle=True)
 
     def prepare_learning(self):
         eval_dataloader = self.eval_pipeline.create_loader(self.config.method.chunk_size)

--- a/trlx/trainer/accelerate_sft_trainer.py
+++ b/trlx/trainer/accelerate_sft_trainer.py
@@ -72,16 +72,18 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
 
         return loss, stats
 
+    def create_train_dataloader(self):
+        return self.accelerator.prepare(self.store.create_loader(self.config.train.batch_size))
+
     def prepare_learning(self):
-        train_dataloader = self.store.create_loader(self.config.train.batch_size)
+        self.train_dataloader = self.create_train_dataloader()
         eval_dataloader = self.eval_pipeline.create_loader(self.config.train.batch_size)
 
         (
             self.model,
             self.opt,
-            self.train_dataloader,
             self.eval_dataloader,
-        ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
+        ) = self.accelerator.prepare(self.model, self.opt, eval_dataloader)
 
         self.n_inner_epochs = 1
         self.total_steps = self.config.train.epochs * len(self.train_dataloader)

--- a/trlx/trainer/accelerate_sft_trainer.py
+++ b/trlx/trainer/accelerate_sft_trainer.py
@@ -83,7 +83,7 @@ class AccelerateSFTTrainer(AccelerateRLTrainer):
             self.eval_dataloader,
         ) = self.accelerator.prepare(self.model, self.opt, train_dataloader, eval_dataloader)
 
-        self.n_updates_per_batch = 1
+        self.n_inner_epochs = 1
         self.total_steps = self.config.train.epochs * len(self.train_dataloader)
         self.total_steps = min(self.total_steps, self.config.train.total_steps)
 


### PR DESCRIPTION
Suppose you have 256 rollouts, and you batch them into batches B1, B2, B3, B4 (each of size 64). The order of gradient updates (assuming 3 ppo_epochs) is:

`trlx: B1 B1 B1 B2 B2 B2 B3 B3 B3 B4 B4 B4`

However, what we should actually be doing (and what alpaca-farm and other rlhf implementations, and standard implementations of PPO do), is

`optimal: B1 B2 B3 B4 B1' B2' B3' B4' B1* B2* B3* B4*`

This change reorders the learning to make the code use the `optimal` ordering above. It also renames n_updates_per_batch to n_inner_epochs as that's a more accurate description (especially now), adjusts forward_time and backward_time to not type-error, and renames mbs and mb to minibatch and microbatch (as that's what they are).