### PR TITLE
Fix: rename model_tok to tokenizer is reward_fn arg

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -431,7 +431,7 @@ class AccelerateRLTrainer(BaseRLTrainer):
                         samples=str_samples,
                         prompts=str_prompts,
                         outputs=str_outputs,
-                        model_tok=self.tokenizer,
+                        tokenizer=self.tokenizer,
                         **metadata,
                     )
                     if isinstance(rewards[0], torch.Tensor):


### PR DESCRIPTION
Fix for https://github.com/CarperAI/trlx/pull/514#discussion_r1268935612