### PR TITLE
mosaicml/mpt support

### DIFF
--- a/trlx/utils/modeling.py
+++ b/trlx/utils/modeling.py
@@ -140,6 +140,7 @@ def hf_get_decoder_blocks(model: nn.Module) -> Tuple[nn.Module]:
         "model.layers",
         "decoder.layers",
         "transformer.h",
+        "transformer.blocks",
         "model.decoder.layers",
         "gpt_neox.layers",
         "decoder.block",


### PR DESCRIPTION
Since the ModuleList in mpt models from mosaicml is named 'transformer.blocks', its unloadable with current trlx. Simply adding the module name, it was able to train the model :)