### PR TITLE
revert(ppo_trainer): keep `save_pretrained` only over the base model

### DIFF
--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -590,11 +590,13 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     ):
                         subfolder = f"checkpoint_{self.iter_count:0{len(str(self.total_steps))}d}"
                         directory = os.path.join(self.config.train.checkpoint_dir, subfolder)
-                        logger.info(f"Saving intermediate checkpoint into {directory}")
                         if self.config.train.save_optimizer:
+                            logger.info(f"Saving intermediate optimizer & model checkpoint into {directory}")
                             self.save(directory)
-                        else:
-                            self.save_pretrained(directory)
+
+                        pretrained_directory = os.path.join(directory, "hf_model")
+                        logger.info(f"Saving pretrained model into {pretrained_directory}")
+                        self.save_pretrained(pretrained_directory)
 
                     stats["time/forward"] = forward_time
                     stats["time/backward"] = backward_time
@@ -623,11 +625,14 @@ class AccelerateRLTrainer(BaseRLTrainer):
                                 torch.distributed.all_reduce(do_save, torch.distributed.ReduceOp.MAX)
                             if do_save:
                                 directory = os.path.join(self.config.train.checkpoint_dir, "best_checkpoint")
-                                logger.info(f"Saving the best state so far into {directory}")
+
                                 if self.config.train.save_optimizer:
+                                    logger.info(f"Saving intermediate optimizer & model checkpoint into {directory}")
                                     self.save(directory)
-                                else:
-                                    self.save_pretrained(directory)
+
+                                pretrained_directory = os.path.join(directory, "hf_model")
+                                logger.info(f"Saving pretrained model into {pretrained_directory}")
+                                self.save_pretrained(pretrained_directory)
 
                     desc = " | ".join(f"{k}: {v:.2f}" for k, v in stats.items() if k.startswith("loss"))
                     tbar.set_description(f"[{desc}]")

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -2,7 +2,7 @@ import json
 import os
 import uuid
 from time import time
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import numpy as np
 import torch
@@ -520,3 +520,32 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
         # Push samples and rewards to trainer's rollout storage
         self.push_to_store(ppo_rl_elements)
+
+    def save_pretrained(self, directory: Optional[str] = None, **kwargs):
+        """
+        Args:
+            directory (str, *optional*): The directory to save the trainer files to.
+                NOTE: If not specified, the model will be saved to a directory named `hf_model` in the
+                checkpoint directory as specified by the Trainer's config.
+            **kwargs: Additional keyword arguments passed to the underlying Hugging Face model's
+                `save_pretrained` method.
+        """
+        if directory is None:
+            directory = os.path.join(self.config.train.checkpoint_dir, "hf_model")
+
+        self.accelerator.wait_for_everyone()
+
+        # Save only the base model, so that is could be loaded directly
+        # with Hugging Face's `from_pretrained` method
+        state_dict = self.accelerator.get_state_dict(self.model.base_model)
+
+        self.accelerator.unwrap_model(self.model).save_pretrained(
+            directory,
+            save_function=self.accelerator.save,
+            is_main_process=self.accelerator.is_main_process,
+            state_dict=state_dict,
+            **kwargs,
+        )
+
+        if self.accelerator.is_main_process:
+            self.tokenizer.save_pretrained(directory)


### PR DESCRIPTION
This PR
- overrides `base_trainer`'s `save_pretrained` just saving the base model inside `*WithHydraValueHead` wrapper `state_dict`
- let trainers always use `save_pretrained` for intermediate checkpoints in `ckpts/checkpoint_000d/hf_model` regardless of the `save_optimizer`'s value (for conveniency, will duplicate model weights if set to true)

Fix of #549 