### PR TITLE
support parallel reward function

### DIFF
--- a/trlx/data/configs.py
+++ b/trlx/data/configs.py
@@ -231,6 +231,8 @@ class TrainConfig:
 
     minibatch_size: Optional[int] = None
 
+    reward_only_in_main_process: bool = True
+
     @classmethod
     def from_dict(cls, config: Dict[str, Any]):
         return cls(**config)

--- a/trlx/trainer/accelerate_base_trainer.py
+++ b/trlx/trainer/accelerate_base_trainer.py
@@ -419,9 +419,11 @@ class AccelerateRLTrainer(BaseRLTrainer):
             if not self.config.train.reward_only_in_main_process or self.accelerator.is_main_process:
                 str_samples, str_prompts, str_outputs = self.decode(all_prompts, all_samples, all_prompt_sizes)
 
-                columns_data = [str_prompts, str_outputs]
-                if not self.config.train.reward_only_in_main_process:
-                    columns_data = self.accelerator.gather_for_metrics(columns_data)
+                if self.accelerator.is_main_process:
+                    columns = ["prompt", "output"]
+                    columns_data = [str_prompts, str_outputs]
+                    if not self.config.train.reward_only_in_main_process:
+                        columns_data = self.accelerator.gather_for_metrics(columns_data)
 
                 metadata, *xs = all_metadata
                 for k in metadata:
@@ -445,12 +447,12 @@ class AccelerateRLTrainer(BaseRLTrainer):
                     else:
                         rewards = torch.tensor(rewards, dtype=float)
 
-                    if not self.config.train.reward_only_in_main_process:
-                        rewards = self.accelerator.gather(rewards)
                     if self.accelerator.is_main_process:
+                        if not self.config.train.reward_only_in_main_process:
+                            rewards = self.accelerator.gather(rewards)
                         mean_reward = rewards.mean().item()
 
-                        columns = ["prompt", "output", "reward"]
+                        columns.append("reward")
                         if not isinstance(rewards, list):
                             rewards = rewards.tolist()
                         columns_data.append(rewards)

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -351,7 +351,10 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
                 scores = all_scores
             scores_mask = scores != -np.inf
 
-            str_samples, str_prompts, str_outputs = self.decode(prompt_tensors, samples, append_eos_token=True)
+            if self.config.train.reward_only_in_main_process:
+                str_samples, str_prompts, str_outputs = self.decode(prompt_tensors, samples, append_eos_token=True)
+            else:
+                str_samples, str_prompts, str_outputs = all_str_samples, all_str_prompts, all_str_outputs
 
             # Pad the sample outputs
             outputs = self.tokenizer(str_outputs).input_ids

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -352,9 +352,9 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             scores_mask = scores != -np.inf
 
             if self.config.train.reward_only_in_main_process:
-                str_samples, str_prompts, str_outputs = self.decode(prompt_tensors, samples, append_eos_token=True)
+                _, _, str_outputs = self.decode(prompt_tensors, samples, append_eos_token=True)
             else:
-                str_samples, str_prompts, str_outputs = all_str_samples, all_str_prompts, all_str_outputs
+                str_outputs = all_str_outputs
 
             # Pad the sample outputs
             outputs = self.tokenizer(str_outputs).input_ids


### PR DESCRIPTION
Currently, reward_fn is invoked only in main_process, which will hang if the reward_fn is actually a parallel model (like: TP/PP/Zero optimized one).

