### PR TITLE
fix model state_dict retrieving in zero3

### DIFF
--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -539,7 +539,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
         # Save only the base model, so that is could be loaded directly
         # with Hugging Face's `from_pretrained` method
-        state_dict = self.accelerator.get_state_dict(self.model.base_model)
+        state_dict = self.accelerator.get_state_dict(self.model, unwrap=True)
 
         self.accelerator.unwrap_model(self.model).save_pretrained(
             directory,


### PR DESCRIPTION
When accelerator retrieves state_dict from model, it will invoke model's `zero_gather_16bit_weights_on_model_save` method for zero3 enabled scenario, which requires the model to be the accelerate wrapped one.

So, We should not use base_model as argument for `state_dict` call, but the wrapped one with `unwrap=True`.

https://github.com/huggingface/accelerate/blob/7843286f2e1c50735d259fbc0084a7f1c85e00e3/src/accelerate/accelerator.py#L3083