### PR TITLE
Faster & memory-efficient logprobs calculation

### DIFF
--- a/trlx/models/modeling_nemo_ppo.py
+++ b/trlx/models/modeling_nemo_ppo.py
@@ -993,7 +993,7 @@ class PPOGPT(MegatronGPTModel):
                 start = batch.query_tensors.shape[1]
                 end = start + response_length
 
-                label_logprobs = logprobs_of_labels(logits[:, :-1, :], inputs[:, 1:])
+                label_logprobs = logprobs_of_labels(logits, inputs[:, 1:])
                 label_logprobs = label_logprobs[:, start:end]
 
                 advantages, returns = self.ppo_config.get_advantages_and_returns(
@@ -1079,11 +1079,11 @@ class PPOGPT(MegatronGPTModel):
                 # to save memory
 
                 if run_policy_model and compute_logprobs:
-                    logprobs = logprobs_of_labels(logits[:, :-1, :], tokens[:, 1:])
+                    logprobs = logprobs_of_labels(logits, tokens[:, 1:])
                     return logprobs, dict(logprobs=logprobs, values=values)
 
                 if run_reference_model and compute_logprobs:
-                    ref_logprobs = logprobs_of_labels(ref_logits[:, :-1, :], tokens[:, 1:])
+                    ref_logprobs = logprobs_of_labels(ref_logits, tokens[:, 1:])
                     return ref_logprobs, dict(ref_logprobs=ref_logprobs)
 
                 return logits, {"logits": logits, "values": values, "ref_logits": ref_logits}

--- a/trlx/trainer/accelerate_ppo_trainer.py
+++ b/trlx/trainer/accelerate_ppo_trainer.py
@@ -163,7 +163,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
 
             logits = outputs.logits
             values_pred = outputs.value
-            logprobs = logprobs_of_labels(logits[:, :-1, :], decoder_input_ids[:, 1:])
+            logprobs = logprobs_of_labels(logits, decoder_input_ids[:, 1:])
             mask = decoder_input_ids.ne(self.tokenizer.pad_token_id).long().to(self.accelerator.device)
             start = 0
             end = start + response_length
@@ -181,7 +181,7 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
             logits = outputs.logits
             values_pred = outputs.value
             values_pred = values_pred[:, :-1]
-            logprobs = logprobs_of_labels(logits[:, :-1, :], tokens[:, 1:])
+            logprobs = logprobs_of_labels(logits, tokens[:, 1:])
 
             start = query_tensors.shape[1] - 1
             end = start + response_length
@@ -438,12 +438,12 @@ class AcceleratePPOTrainer(AccelerateRLTrainer):
                         ref_logits = ref_logits.to(device)
 
             if self.config.model.model_arch_type == "seq2seq":
-                logprobs = logprobs_of_labels(logits[:, :-1, :], sample_outputs[:, 1:])
-                ref_logprobs = logprobs_of_labels(ref_logits[:, :-1, :], sample_outputs[:, 1:])
+                logprobs = logprobs_of_labels(logits, sample_outputs[:, 1:])
+                ref_logprobs = logprobs_of_labels(ref_logits, sample_outputs[:, 1:])
             else:
                 # NOTE: logprob[i] is (log)prob at which all_token[i+1] was sampled
-                logprobs = logprobs_of_labels(logits[:, :-1, :], all_tokens[:, 1:])
-                ref_logprobs = logprobs_of_labels(ref_logits[:, :-1, :], all_tokens[:, 1:])
+                logprobs = logprobs_of_labels(logits, all_tokens[:, 1:])
+                ref_logprobs = logprobs_of_labels(ref_logits, all_tokens[:, 1:])
 
             n_samples: int = samples.shape[0]
 


### PR DESCRIPTION
The current `logprobs_of_labels` computes logprobs using a `log_softmax` followed by a `gather`. When the input logits is not contiguous, the `log_softmax` will make a copy of the logits, which is very large (batch_size * seq_len * vocab_size can be 32 * 2048 * 64000 * 2B = 8GB for typical settings).

This PR directly feeds the contiguous logits into `log_softmax` so as to reduce the peak cuda memory and remove redundant copy.

Test script:
```python
import torch
from torch.utils.benchmark import Timer
from trlx.utils.modeling import logprobs_of_labels

def perf():
    batch_size, seq_len, vocab_size = 32, 2048, 64000
    logits = torch.randn((batch_size, seq_len, vocab_size), dtype=torch.half, device='cuda')
    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), dtype=torch.long, device='cuda')

    # correctness
    assert torch.allclose(logprobs_of_labels(logits[:, :-1, :], input_ids[:, 1:]), logprobs_of_labels(logits, input_ids[:, 1:]))

    # peak memory test
    torch.cuda.empty_cache()
    logprobs_of_labels(logits[:, :-1, :], input_ids[:, 1:])
    print(f'original allocated: {torch.cuda.memory_allocated() / 1e9:.3f} GB, reserved: {torch.cuda.memory_reserved() / 1e9:.3f} GB')

    torch.cuda.empty_cache()
    logprobs_of_labels(logits, input_ids[:, 1:])
    print(f'optimized allocated: {torch.cuda.memory_allocated() / 1e9:.3f} GB, reserved: {torch.cuda.memory_reserved() / 1e9:.3f} GB')

    # speed test
    timer = Timer(stmt="logprobs_of_labels(logits[:, :-1, :], input_ids[:, 1:])", globals={**globals(), **locals()})
    elapsed_org = timer.timeit(100).mean
    print(f'original costs: {elapsed_org:.4f} s')

    timer = Timer(stmt="logprobs_of_labels(logits, input_ids[:, 1:])", globals={**globals(), **locals()})
    elapsed_opt = timer.timeit(100).mean
    print(f'optimized costs: {elapsed_opt:.4f} s')

perf()
```

Tested on a Tesla V100, method in this PR is both faster (1.6x speedup) and memory-efficient.
```
original allocated: 8.389 GB, reserved: 25.164 GB
optimized allocated: 8.389 GB, reserved: 16.779 GB
original costs: 0.0700 s
optimized costs: 0.0435 s
```